### PR TITLE
feat: support multiple activity entry images

### DIFF
--- a/apps/backend-node/src/routes/activities.ts
+++ b/apps/backend-node/src/routes/activities.ts
@@ -6,11 +6,48 @@ import multer from "multer";
 import { v4 as uuidv4 } from "uuid";
 import { notificationService } from "../services/notificationService";
 import { s3Service } from "../services/s3Service";
+import { buildActivityEntryImageUpdate } from "../utils/activityEntryImages";
 import { logger } from "../utils/logger";
 import { prisma } from "../utils/prisma";
 
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
+
+const activityEntryPhotoUpload = upload.fields([
+  { name: "photo", maxCount: 10 },
+  { name: "photos", maxCount: 10 },
+]);
+
+const getUploadedActivityEntryPhotos = (req: AuthenticatedRequest) => {
+  const files = req.files as
+    | { [fieldname: string]: Express.Multer.File[] }
+    | undefined;
+
+  return [...(files?.photo || []), ...(files?.photos || [])];
+};
+
+const uploadActivityEntryPhotos = async (
+  photos: Express.Multer.File[],
+  userId: string,
+  activityEntryId: string
+) => {
+  return Promise.all(
+    photos.map(async (photo) => {
+      const photoId = uuidv4();
+      const fileExtension = photo.originalname
+        ? photo.originalname.split(".").pop()
+        : "jpg";
+      const s3Path = `/users/${userId}/activity_entries/${activityEntryId}/photos/${photoId}.${fileExtension}`;
+
+      await s3Service.upload(photo.buffer, s3Path, photo.mimetype);
+
+      return {
+        s3Path,
+        url: s3Service.getPublicUrl(s3Path),
+      };
+    })
+  );
+};
 
 // Get all activities for user
 router.get(
@@ -90,7 +127,7 @@ router.get(
 router.post(
   "/log-activity",
   requireAuth,
-  upload.single("photo"),
+  activityEntryPhotoUpload,
   async (
     req: AuthenticatedRequest,
     res: Response
@@ -107,7 +144,7 @@ router.post(
         description,
         timezone,
       } = req.body;
-      const photo = req.file;
+      const photos = getUploadedActivityEntryPhotos(req);
 
       // Check if activity exists and belongs to user
       const activity = await prisma.activity.findFirst({
@@ -157,33 +194,27 @@ router.post(
       }
 
       // Handle photo upload if provided
-      if (photo) {
+      if (photos.length > 0) {
         try {
-          const photoId = uuidv4();
-          const fileExtension = photo.originalname
-            ? photo.originalname.split(".").pop()
-            : "jpg";
-          const s3Path = `/users/${req.user!.id}/activity_entries/${entry.id}/photos/${photoId}.${fileExtension}`;
-
-          // Upload to S3
-          await s3Service.upload(photo.buffer, s3Path, photo.mimetype);
-
-          // Use public URL (bucket policy allows public read for activity_entries photos)
-          const publicUrl = s3Service.getPublicUrl(s3Path);
+          const uploadedImages = await uploadActivityEntryPhotos(
+            photos,
+            req.user!.id,
+            entry.id
+          );
 
           // Update entry with image information
           entry = await prisma.activityEntry.update({
             where: { id: entry.id },
-            data: {
-              imageS3Path: s3Path,
-              imageUrl: publicUrl,
-              imageExpiresAt: null, // No expiration for public URLs
-              imageCreatedAt: new Date(),
-              imageIsPublic: isPublic === "true" || isPublic === true,
-            },
+            data: buildActivityEntryImageUpdate(
+              entry,
+              uploadedImages,
+              isPublic === "true" || isPublic === true
+            ),
           });
 
-          logger.info(`Photo uploaded successfully to S3: ${s3Path}`);
+          logger.info(
+            `${uploadedImages.length} photo(s) uploaded successfully to S3 for activity entry ${entry.id}`
+          );
 
           // Create notifications for connected users about the photo
           const userWithConnections = await prisma.user.findUnique({
@@ -207,7 +238,7 @@ router.post(
             ];
 
             for (const connectedUser of connectedUsers) {
-              const message = `${req.user!.username} logged ${quantity} ${activity.measure} of ${activity.emoji} ${activity.title} with a photo 📸!`;
+              const message = `${req.user!.username} logged ${quantity} ${activity.measure} of ${activity.emoji} ${activity.title} with ${uploadedImages.length === 1 ? "a photo" : `${uploadedImages.length} photos`} 📸!`;
               await notificationService.createAndProcessNotification({
                 userId: connectedUser.id,
                 message,
@@ -467,17 +498,17 @@ router.put(
 router.put(
   "/activity-entries/:activityEntryId/photo",
   requireAuth,
-  upload.single("photo"),
+  activityEntryPhotoUpload,
   async (
     req: AuthenticatedRequest,
     res: Response
   ): Promise<Response | void> => {
     try {
       const { activityEntryId } = req.params;
-      const photo = req.file;
+      const photos = getUploadedActivityEntryPhotos(req);
 
-      if (!photo) {
-        return res.status(400).json({ error: "No photo provided" });
+      if (photos.length === 0) {
+        return res.status(400).json({ error: "No photos provided" });
       }
 
       // Verify ownership
@@ -503,40 +534,21 @@ router.put(
         });
       }
 
-      // Delete old photo from S3 if it exists
-      if (existingEntry.imageS3Path) {
-        try {
-          await s3Service.delete(existingEntry.imageS3Path);
-          logger.info(`Deleted old photo from S3: ${existingEntry.imageS3Path}`);
-        } catch (error) {
-          logger.warn(`Failed to delete old photo from S3: ${existingEntry.imageS3Path}`, error);
-        }
-      }
+      const uploadedImages = await uploadActivityEntryPhotos(
+        photos,
+        req.user!.id,
+        existingEntry.id
+      );
 
-      // Upload new photo
-      const photoId = uuidv4();
-      const fileExtension = photo.originalname
-        ? photo.originalname.split(".").pop()
-        : "jpg";
-      const s3Path = `/users/${req.user!.id}/activity_entries/${existingEntry.id}/photos/${photoId}.${fileExtension}`;
-
-      await s3Service.upload(photo.buffer, s3Path, photo.mimetype);
-
-      // Use public URL
-      const publicUrl = s3Service.getPublicUrl(s3Path);
-
-      // Update entry with new image information
+      // Append new images while preserving existing ones
       const updatedEntry = await prisma.activityEntry.update({
         where: { id: activityEntryId },
-        data: {
-          imageS3Path: s3Path,
-          imageUrl: publicUrl,
-          imageExpiresAt: null,
-          imageCreatedAt: new Date(),
-        },
+        data: buildActivityEntryImageUpdate(existingEntry, uploadedImages),
       });
 
-      logger.info(`Photo updated successfully for activity entry ${activityEntryId}`);
+      logger.info(
+        `${uploadedImages.length} photo(s) added successfully for activity entry ${activityEntryId}`
+      );
 
       res.json(updatedEntry);
     } catch (error) {
@@ -580,16 +592,26 @@ router.delete(
         });
       }
 
-      if (!existingEntry.imageS3Path) {
+      const imageS3Paths = Array.from(
+        new Set([
+          ...((existingEntry as typeof existingEntry & { imageS3Paths?: string[] })
+            .imageS3Paths || []),
+          existingEntry.imageS3Path,
+        ].filter((path): path is string => !!path))
+      );
+
+      if (imageS3Paths.length === 0) {
         return res.status(404).json({ error: "No photo to delete" });
       }
 
-      // Delete photo from S3
-      try {
-        await s3Service.delete(existingEntry.imageS3Path);
-        logger.info(`Deleted photo from S3: ${existingEntry.imageS3Path}`);
-      } catch (error) {
-        logger.warn(`Failed to delete photo from S3: ${existingEntry.imageS3Path}`, error);
+      // Delete photos from S3
+      for (const imageS3Path of imageS3Paths) {
+        try {
+          await s3Service.delete(imageS3Path);
+          logger.info(`Deleted photo from S3: ${imageS3Path}`);
+        } catch (error) {
+          logger.warn(`Failed to delete photo from S3: ${imageS3Path}`, error);
+        }
       }
 
       // Clear image fields
@@ -598,6 +620,8 @@ router.delete(
         data: {
           imageS3Path: null,
           imageUrl: null,
+          imageS3Paths: [],
+          imageUrls: [],
           imageExpiresAt: null,
           imageCreatedAt: null,
         },

--- a/apps/backend-node/src/utils/__tests__/activityEntryImages.test.ts
+++ b/apps/backend-node/src/utils/__tests__/activityEntryImages.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { buildActivityEntryImageUpdate } from "../activityEntryImages";
+
+describe("buildActivityEntryImageUpdate", () => {
+  it("appends uploaded images while preserving legacy first-image fields", () => {
+    const update = buildActivityEntryImageUpdate(
+      {
+        imageUrl: "https://cdn.example.com/old.jpg",
+        imageS3Path: "/users/u1/activity_entries/e1/photos/old.jpg",
+        imageUrls: [],
+        imageS3Paths: [],
+      },
+      [
+        {
+          url: "https://cdn.example.com/new-1.jpg",
+          s3Path: "/users/u1/activity_entries/e1/photos/new-1.jpg",
+        },
+        {
+          url: "https://cdn.example.com/new-2.jpg",
+          s3Path: "/users/u1/activity_entries/e1/photos/new-2.jpg",
+        },
+      ],
+      true
+    );
+
+    expect(update.imageUrl).toBe("https://cdn.example.com/old.jpg");
+    expect(update.imageS3Path).toBe(
+      "/users/u1/activity_entries/e1/photos/old.jpg"
+    );
+    expect(update.imageUrls).toEqual([
+      "https://cdn.example.com/old.jpg",
+      "https://cdn.example.com/new-1.jpg",
+      "https://cdn.example.com/new-2.jpg",
+    ]);
+    expect(update.imageS3Paths).toEqual([
+      "/users/u1/activity_entries/e1/photos/old.jpg",
+      "/users/u1/activity_entries/e1/photos/new-1.jpg",
+      "/users/u1/activity_entries/e1/photos/new-2.jpg",
+    ]);
+    expect(update.imageExpiresAt).toBeNull();
+    expect(update.imageCreatedAt).toBeInstanceOf(Date);
+    expect(update.imageIsPublic).toBe(true);
+  });
+
+  it("sets legacy fields from the first uploaded image when none exists", () => {
+    const update = buildActivityEntryImageUpdate(
+      {},
+      [
+        {
+          url: "https://cdn.example.com/first.jpg",
+          s3Path: "/users/u1/activity_entries/e1/photos/first.jpg",
+        },
+      ],
+      false
+    );
+
+    expect(update.imageUrl).toBe("https://cdn.example.com/first.jpg");
+    expect(update.imageS3Path).toBe(
+      "/users/u1/activity_entries/e1/photos/first.jpg"
+    );
+    expect(update.imageUrls).toEqual(["https://cdn.example.com/first.jpg"]);
+    expect(update.imageS3Paths).toEqual([
+      "/users/u1/activity_entries/e1/photos/first.jpg",
+    ]);
+    expect(update.imageIsPublic).toBe(false);
+  });
+});

--- a/apps/backend-node/src/utils/activityEntryImages.ts
+++ b/apps/backend-node/src/utils/activityEntryImages.ts
@@ -1,0 +1,45 @@
+export interface ActivityEntryImageFields {
+  imageUrl?: string | null;
+  imageS3Path?: string | null;
+  imageUrls?: string[] | null;
+  imageS3Paths?: string[] | null;
+}
+
+export interface UploadedActivityEntryImage {
+  url: string;
+  s3Path: string;
+}
+
+const uniqueTruthy = (values: Array<string | null | undefined>) =>
+  Array.from(new Set(values.filter((value): value is string => !!value)));
+
+export const getActivityEntryImageUrls = (entry: ActivityEntryImageFields) =>
+  uniqueTruthy([...(entry.imageUrls || []), entry.imageUrl]);
+
+export const getActivityEntryImageS3Paths = (entry: ActivityEntryImageFields) =>
+  uniqueTruthy([...(entry.imageS3Paths || []), entry.imageS3Path]);
+
+export const buildActivityEntryImageUpdate = (
+  existingEntry: ActivityEntryImageFields,
+  uploadedImages: UploadedActivityEntryImage[],
+  isPublic?: boolean
+) => {
+  const imageUrls = uniqueTruthy([
+    ...getActivityEntryImageUrls(existingEntry),
+    ...uploadedImages.map((image) => image.url),
+  ]);
+  const imageS3Paths = uniqueTruthy([
+    ...getActivityEntryImageS3Paths(existingEntry),
+    ...uploadedImages.map((image) => image.s3Path),
+  ]);
+
+  return {
+    imageS3Path: imageS3Paths[0] || null,
+    imageUrl: imageUrls[0] || null,
+    imageS3Paths,
+    imageUrls,
+    imageExpiresAt: null,
+    imageCreatedAt: new Date(),
+    ...(typeof isPublic === "boolean" ? { imageIsPublic: isPublic } : {}),
+  };
+};

--- a/apps/frontend-vite/src/components/ActivityEntryEditor.tsx
+++ b/apps/frontend-vite/src/components/ActivityEntryEditor.tsx
@@ -1,11 +1,12 @@
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
+import MultiPhotoUploader from "@/components/ui/MultiPhotoUploader";
 import { Textarea } from "@/components/ui/textarea";
 import { useActivities } from "@/contexts/activities/useActivities";
 import { differenceInDays } from "date-fns";
-import { Camera, ImagePlus, Loader2, Pencil, Trash2, X } from "lucide-react";
+import { Camera, Loader2, Pencil, Trash2 } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import Picker from "react-mobile-picker";
 import AppleLikePopover from "./AppleLikePopover";
 import ConfirmDialogOrPopover from "./ConfirmDialogOrPopover";
@@ -17,6 +18,7 @@ interface ActivityEntry {
   activityId: string;
   description?: string;
   imageUrl?: string | null;
+  imageUrls?: string[];
   createdAt?: Date;
 }
 
@@ -42,10 +44,8 @@ const ActivityEntryEditor: React.FC<ActivityEntryEditorProps> = ({
   const [description, setDescription] = useState(activityEntry.description || "");
   const [isTimePickerExpanded, setIsTimePickerExpanded] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [selectedPhoto, setSelectedPhoto] = useState<File | null>(null);
-  const [photoPreview, setPhotoPreview] = useState<string | null>(null);
+  const [selectedPhotos, setSelectedPhotos] = useState<File[]>([]);
   const [showDeletePhotoConfirm, setShowDeletePhotoConfirm] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const {
     upsertActivityEntry,
@@ -62,28 +62,21 @@ const ActivityEntryEditor: React.FC<ActivityEntryEditorProps> = ({
   // Check if entry is within last 7 days (for photo editing)
   const entryCreatedAt = activityEntry.createdAt ? new Date(activityEntry.createdAt) : entryDate;
   const canEditPhoto = differenceInDays(new Date(), entryCreatedAt) <= 7;
-  const hasExistingPhoto = !!activityEntry.imageUrl;
-
-  const handlePhotoSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setSelectedPhoto(file);
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setPhotoPreview(reader.result as string);
-      };
-      reader.readAsDataURL(file);
-    }
-  };
+  const imageUrls = Array.from(
+    new Set([
+      ...(activityEntry.imageUrls || []),
+      activityEntry.imageUrl,
+    ].filter((url): url is string => !!url))
+  );
+  const hasExistingPhoto = imageUrls.length > 0;
 
   const handlePhotoUpload = async () => {
-    if (!selectedPhoto) return;
+    if (selectedPhotos.length === 0) return;
     await updateActivityEntryPhoto({
       activityEntryId: activityEntry.id,
-      photo: selectedPhoto,
+      photos: selectedPhotos,
     });
-    setSelectedPhoto(null);
-    setPhotoPreview(null);
+    setSelectedPhotos([]);
   };
 
   const handlePhotoDelete = async () => {
@@ -91,14 +84,6 @@ const ActivityEntryEditor: React.FC<ActivityEntryEditorProps> = ({
       activityEntryId: activityEntry.id,
     });
     setShowDeletePhotoConfirm(false);
-  };
-
-  const clearSelectedPhoto = () => {
-    setSelectedPhoto(null);
-    setPhotoPreview(null);
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
   };
 
   const activity = activities.find((a) => a.id === activityEntry.activityId);
@@ -277,75 +262,28 @@ const ActivityEntryEditor: React.FC<ActivityEntryEditorProps> = ({
         {/* Photo Section */}
         {canEditPhoto && (
           <div>
-            <h3 className="text-lg font-semibold mb-2 text-center">Photo</h3>
-            <input
-              type="file"
-              accept="image/*"
-              onChange={handlePhotoSelect}
-              ref={fileInputRef}
-              className="hidden"
-            />
+            <h3 className="text-lg font-semibold mb-2 text-center">Photos</h3>
 
-            {/* Show current photo or selected photo preview */}
-            {(photoPreview || activityEntry.imageUrl) && (
-              <div className="relative mb-3">
-                <img
-                  src={photoPreview || activityEntry.imageUrl || ""}
-                  alt="Activity photo"
-                  className="w-full max-h-48 object-cover rounded-lg"
-                />
-                {photoPreview && (
-                  <button
-                    onClick={clearSelectedPhoto}
-                    className="absolute top-2 right-2 p-1 bg-black/50 rounded-full hover:bg-black/70 transition-colors"
-                  >
-                    <X className="w-4 h-4 text-white" />
-                  </button>
-                )}
+            {hasExistingPhoto && (
+              <div className="grid grid-cols-2 gap-2 mb-3">
+                {imageUrls.map((imageUrl) => (
+                  <img
+                    key={imageUrl}
+                    src={imageUrl}
+                    alt="Activity photo"
+                    className="w-full aspect-square object-cover rounded-lg"
+                  />
+                ))}
               </div>
             )}
 
-            {/* Photo action buttons */}
-            <div className="flex gap-2 justify-center">
-              {!photoPreview && !hasExistingPhoto && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => fileInputRef.current?.click()}
-                  className="flex-1"
-                >
-                  <ImagePlus className="w-4 h-4 mr-2" />
-                  Add Photo
-                </Button>
-              )}
+            <MultiPhotoUploader
+              onFilesChange={setSelectedPhotos}
+              disabled={isUpdatingActivityEntryPhoto}
+            />
 
-              {!photoPreview && hasExistingPhoto && (
-                <>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => fileInputRef.current?.click()}
-                    className="flex-1"
-                  >
-                    <Camera className="w-4 h-4 mr-2" />
-                    Change Photo
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    onClick={() => setShowDeletePhotoConfirm(true)}
-                    disabled={isDeletingActivityEntryPhoto}
-                  >
-                    {isDeletingActivityEntryPhoto ? (
-                      <Loader2 className="w-4 h-4 animate-spin" />
-                    ) : (
-                      <Trash2 className="w-4 h-4" />
-                    )}
-                  </Button>
-                </>
-              )}
-
-              {photoPreview && (
+            <div className="flex gap-2 justify-center mt-3">
+              {selectedPhotos.length > 0 && (
                 <Button
                   type="button"
                   onClick={handlePhotoUpload}
@@ -360,8 +298,23 @@ const ActivityEntryEditor: React.FC<ActivityEntryEditorProps> = ({
                   ) : (
                     <>
                       <Camera className="w-4 h-4 mr-2" />
-                      Upload Photo
+                      Add {selectedPhotos.length} photo{selectedPhotos.length === 1 ? "" : "s"}
                     </>
+                  )}
+                </Button>
+              )}
+
+              {hasExistingPhoto && (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={() => setShowDeletePhotoConfirm(true)}
+                  disabled={isDeletingActivityEntryPhoto}
+                >
+                  {isDeletingActivityEntryPhoto ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="w-4 h-4" />
                   )}
                 </Button>
               )}
@@ -371,12 +324,17 @@ const ActivityEntryEditor: React.FC<ActivityEntryEditorProps> = ({
 
         {!canEditPhoto && hasExistingPhoto && (
           <div>
-            <h3 className="text-lg font-semibold mb-2 text-center">Photo</h3>
-            <img
-              src={activityEntry.imageUrl || ""}
-              alt="Activity photo"
-              className="w-full max-h-48 object-cover rounded-lg mb-2"
-            />
+            <h3 className="text-lg font-semibold mb-2 text-center">Photos</h3>
+            <div className="grid grid-cols-2 gap-2 mb-2">
+              {imageUrls.map((imageUrl) => (
+                <img
+                  key={imageUrl}
+                  src={imageUrl}
+                  alt="Activity photo"
+                  className="w-full aspect-square object-cover rounded-lg"
+                />
+              ))}
+            </div>
             <p className="text-xs text-muted-foreground text-center">
               Photos can only be edited within 7 days of the entry
             </p>
@@ -427,8 +385,8 @@ const ActivityEntryEditor: React.FC<ActivityEntryEditorProps> = ({
           isOpen={showDeletePhotoConfirm}
           onClose={() => setShowDeletePhotoConfirm(false)}
           onConfirm={handlePhotoDelete}
-          title="Delete Photo"
-          description="Are you sure you want to delete this photo?"
+          title="Delete Photos"
+          description="Are you sure you want to delete all photos for this entry?"
           confirmText="Delete"
           cancelText="Cancel"
           variant="destructive"

--- a/apps/frontend-vite/src/components/ActivityEntryPhotoCard.tsx
+++ b/apps/frontend-vite/src/components/ActivityEntryPhotoCard.tsx
@@ -321,7 +321,16 @@ const ActivityEntryPhotoCard: React.FC<ActivityEntryPhotoCardProps> = ({
     }`;
   };
 
-  const hasImage = !!activityEntry.imageUrl;
+  const imageUrls = Array.from(
+    new Set(
+      [
+        ...((activityEntry as typeof activityEntry & { imageUrls?: string[] })
+          .imageUrls || []),
+        activityEntry.imageUrl,
+      ].filter((url): url is string => !!url)
+    )
+  );
+  const hasImage = imageUrls.length > 0;
   const shouldShowNeonEffect = habitAchieved || lifestyleAchieved;
 
   // Extract first URL from description for link preview
@@ -390,11 +399,28 @@ const ActivityEntryPhotoCard: React.FC<ActivityEntryPhotoCardProps> = ({
       {hasImage && (
         <div className="relative max-h-full max-w-full mx-auto p-4 pb-0">
           <div className="relative rounded-2xl overflow-hidden backdrop-blur-lg shadow-lg border border-white/20">
-            <img
-              src={activityEntry.imageUrl || ""}
-              alt={activity.title}
-              className="w-full h-full max-h-[400px] object-cover rounded-2xl"
-            />
+            {imageUrls.length === 1 ? (
+              <img
+                src={imageUrls[0]}
+                alt={activity.title}
+                className="w-full h-full max-h-[400px] object-cover rounded-2xl"
+              />
+            ) : (
+              <div className="grid grid-cols-2 gap-1">
+                {imageUrls.map((imageUrl, index) => (
+                  <img
+                    key={imageUrl}
+                    src={imageUrl}
+                    alt={`${activity.title} proof ${index + 1}`}
+                    className={`w-full object-cover ${
+                      index === 0 && imageUrls.length === 3
+                        ? "col-span-2 max-h-[300px]"
+                        : "aspect-square"
+                    }`}
+                  />
+                ))}
+              </div>
+            )}
             <div className="absolute top-2 left-2 flex flex-col flex-nowrap items-start gap-2 z-30">
               {reactions &&
                 Object.entries(reactions).map(([emoji, usernames]) => {

--- a/apps/frontend-vite/src/components/ActivityPhotoUploader.tsx
+++ b/apps/frontend-vite/src/components/ActivityPhotoUploader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import PhotoUploader from "@/components/ui/photo-uploader";
+import MultiPhotoUploader from "@/components/ui/MultiPhotoUploader";
 import { TextAreaWithVoice } from "@/components/ui/text-area-with-voice";
 import { useActivities } from "@/contexts/activities/useActivities";
 import { useNotifications } from "@/hooks/useNotifications";
@@ -29,7 +29,7 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
   onSuccess,
   open,
 }) => {
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [description, setDescription] = useState("");
   const { logActivity: submitActivity, isLoggingActivity } = useActivities();
   const { addToNotificationCount } = useNotifications();
@@ -41,7 +41,7 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
         datetime: activityData.datetime,
         quantity: activityData.quantity,
         description,
-        photo: selectedFile || undefined,
+        photos: selectedFiles,
       });
 
       if (!entry?.id) {
@@ -61,11 +61,9 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
       <h2 className="text-2xl font-bold mb-4">📸 Add a proof!</h2>
       <div className="space-y-4">
         <div className="flex justify-center">
-          <PhotoUploader
-            onFileSelect={setSelectedFile}
-            placeholder="Click to upload a photo"
+          <MultiPhotoUploader
+            onFilesChange={setSelectedFiles}
             disabled={isLoggingActivity}
-            className="w-full"
           />
         </div>
         <TextAreaWithVoice
@@ -91,7 +89,9 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
           {isLoggingActivity ? (
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
           ) : null}
-          {selectedFile ? "Upload" : "Log without photo"}
+          {selectedFiles.length > 0
+            ? `Upload ${selectedFiles.length} photo${selectedFiles.length === 1 ? "" : "s"}`
+            : "Log without photo"}
         </Button>
       </div>
     </AppleLikePopover>

--- a/apps/frontend-vite/src/contexts/activities/provider.tsx
+++ b/apps/frontend-vite/src/contexts/activities/provider.tsx
@@ -60,8 +60,9 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
         Intl.DateTimeFormat().resolvedOptions().timeZone
       );
 
-      if (data.photo) {
-        formData.append("photo", data.photo);
+      const photos = data.photos || (data.photo ? [data.photo] : []);
+      for (const photo of photos) {
+        formData.append("photos", photo);
       }
 
       const response = await api.post("/activities/log-activity", formData);
@@ -89,7 +90,7 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
       // is available for achievement detection
       await queryClient.refetchQueries({ queryKey: ["plans"] });
 
-      const hasPhoto = !!variables.photo;
+      const hasPhoto = !!variables.photo || !!variables.photos?.length;
       toast.success(
         hasPhoto
           ? "Activity logged with photo successfully!"
@@ -595,9 +596,12 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
   });
 
   const updateActivityEntryPhotoMutation = useMutation({
-    mutationFn: async (data: { activityEntryId: string; photo: File }) => {
+    mutationFn: async (data: { activityEntryId: string; photo?: File; photos?: File[] }) => {
       const formData = new FormData();
-      formData.append("photo", data.photo);
+      const photos = data.photos || (data.photo ? [data.photo] : []);
+      for (const photo of photos) {
+        formData.append("photos", photo);
+      }
 
       const response = await api.put(
         `/activities/activity-entries/${data.activityEntryId}/photo`,

--- a/apps/frontend-vite/src/contexts/activities/types.ts
+++ b/apps/frontend-vite/src/contexts/activities/types.ts
@@ -12,6 +12,7 @@ export interface ActivityLogData {
   quantity: number;
   description?: string;
   photo?: File;
+  photos?: File[];
 }
 
 export interface ActivitiesContextType {
@@ -86,7 +87,8 @@ export interface ActivitiesContextType {
 
   updateActivityEntryPhoto: (data: {
     activityEntryId: string;
-    photo: File;
+    photo?: File;
+    photos?: File[];
   }) => Promise<ActivityEntry>;
   deleteActivityEntryPhoto: (data: {
     activityEntryId: string;

--- a/packages/prisma/migrations/20260506160000_add_activity_entry_image_arrays/migration.sql
+++ b/packages/prisma/migrations/20260506160000_add_activity_entry_image_arrays/migration.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "public"."activity_entries"
+  ADD COLUMN IF NOT EXISTS "imageS3Paths" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  ADD COLUMN IF NOT EXISTS "imageUrls" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+UPDATE "public"."activity_entries"
+SET
+  "imageS3Paths" = CASE
+    WHEN "imageS3Path" IS NOT NULL AND array_length("imageS3Paths", 1) IS NULL THEN ARRAY["imageS3Path"]::TEXT[]
+    ELSE "imageS3Paths"
+  END,
+  "imageUrls" = CASE
+    WHEN "imageUrl" IS NOT NULL AND array_length("imageUrls", 1) IS NULL THEN ARRAY["imageUrl"]::TEXT[]
+    ELSE "imageUrls"
+  END;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -165,6 +165,8 @@ model ActivityEntry {
   // Image info
   imageS3Path    String?
   imageUrl       String?
+  imageS3Paths   String[]  @default([])
+  imageUrls      String[]  @default([])
   imageExpiresAt DateTime?
   imageCreatedAt DateTime?
   imageIsPublic  Boolean   @default(false)


### PR DESCRIPTION
## Summary
- Add `imageUrls` / `imageS3Paths` arrays to activity entries while preserving legacy first-image fields
- Accept multiple uploaded photos when logging an activity or adding proofs from the entry editor
- Render activity entries with multiple images in a grid
- Add helper tests for appending images and preserving legacy fields

## Test Plan
- [x] `pnpm --filter @tsw/prisma db:generate`
- [x] `pnpm exec vitest run src/utils/__tests__/activityEntryImages.test.ts --bail=1` in `apps/backend-node`
- [x] `pnpm build` in `apps/backend-node`
- [x] `pnpm build` in `apps/frontend-vite`