### PR TITLE
feat: link joint activities with friends

### DIFF
--- a/apps/backend-node/src/routes/activities.ts
+++ b/apps/backend-node/src/routes/activities.ts
@@ -8,9 +8,211 @@ import { notificationService } from "../services/notificationService";
 import { s3Service } from "../services/s3Service";
 import { logger } from "../utils/logger";
 import { prisma } from "../utils/prisma";
+import { scoreSharedActivityCandidate } from "../utils/sharedActivities";
 
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
+
+
+const sharedActivityInclude = {
+  include: {
+    sharedActivity: {
+      include: {
+        entries: {
+          include: {
+            user: {
+              select: { id: true, username: true, name: true, picture: true },
+            },
+            activityEntry: {
+              select: { id: true, userId: true, deletedAt: true },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+const activityEntrySocialInclude = {
+  comments: {
+    where: { deletedAt: null },
+    include: {
+      user: {
+        select: {
+          id: true,
+          username: true,
+          picture: true,
+        },
+      },
+    },
+    orderBy: { createdAt: "asc" as const },
+  },
+  reactions: {
+    include: {
+      user: {
+        select: {
+          id: true,
+          username: true,
+          picture: true,
+        },
+      },
+    },
+  },
+  sharedActivityEntry: sharedActivityInclude,
+};
+
+async function getAcceptedConnectionIds(userId: string): Promise<string[]> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    include: {
+      connectionsFrom: { where: { status: "ACCEPTED" }, select: { toId: true } },
+      connectionsTo: { where: { status: "ACCEPTED" }, select: { fromId: true } },
+    },
+  });
+
+  if (!user) return [];
+  return [
+    ...user.connectionsFrom.map((connection) => connection.toId),
+    ...user.connectionsTo.map((connection) => connection.fromId),
+  ];
+}
+
+async function getVisibleActivityIdsForUsers(userIds: string[]): Promise<Set<string>> {
+  if (!userIds.length) return new Set();
+
+  const [activities, publicPlans] = await Promise.all([
+    prisma.activity.findMany({
+      where: { userId: { in: userIds }, deletedAt: null },
+      select: { id: true },
+    }),
+    prisma.plan.findMany({
+      where: {
+        userId: { in: userIds },
+        deletedAt: null,
+        visibility: "PUBLIC",
+      },
+      select: { activities: { select: { id: true } } },
+    }),
+  ]);
+
+  const publicActivityIds = new Set<string>();
+  publicPlans.forEach((plan) => {
+    plan.activities.forEach((activity) => publicActivityIds.add(activity.id));
+  });
+
+  const plannedActivityIds = new Set<string>();
+  const allPlans = await prisma.plan.findMany({
+    where: { userId: { in: userIds }, deletedAt: null },
+    select: { activities: { select: { id: true } } },
+  });
+  allPlans.forEach((plan) => {
+    plan.activities.forEach((activity) => plannedActivityIds.add(activity.id));
+  });
+
+  return new Set(
+    activities
+      .filter((activity) => publicActivityIds.has(activity.id) || !plannedActivityIds.has(activity.id))
+      .map((activity) => activity.id)
+  );
+}
+
+async function findSharedActivityCandidates(activityEntryId: string, userId: string) {
+  const entry = await prisma.activityEntry.findFirst({
+    where: { id: activityEntryId, userId, deletedAt: null, activityId: { not: null } },
+    include: { activity: true, sharedActivityEntry: true },
+  });
+
+  if (!entry?.activity || entry.sharedActivityEntry) return [];
+
+  const connectionIds = await getAcceptedConnectionIds(userId);
+  if (!connectionIds.length) return [];
+
+  const visibleActivityIds = await getVisibleActivityIdsForUsers(connectionIds);
+  if (!visibleActivityIds.size) return [];
+
+  const start = new Date(entry.datetime.getTime() - 3 * 60 * 60 * 1000);
+  const end = new Date(entry.datetime.getTime() + 3 * 60 * 60 * 1000);
+
+  const candidates = await prisma.activityEntry.findMany({
+    where: {
+      userId: { in: connectionIds },
+      deletedAt: null,
+      activityId: { in: Array.from(visibleActivityIds) },
+      datetime: { gte: start, lte: end },
+      sharedActivityEntry: null,
+    },
+    include: {
+      activity: true,
+      user: { select: { id: true, username: true, name: true, picture: true } },
+    },
+    take: 20,
+  });
+
+  return candidates
+    .map((candidate) => ({
+      candidate,
+      score: candidate.activity
+        ? scoreSharedActivityCandidate({
+            sourceTitle: entry.activity!.title,
+            sourceMeasure: entry.activity!.measure,
+            sourceEmoji: entry.activity!.emoji,
+            sourceDatetime: entry.datetime,
+            candidateTitle: candidate.activity.title,
+            candidateMeasure: candidate.activity.measure,
+            candidateEmoji: candidate.activity.emoji,
+            candidateDatetime: candidate.datetime,
+          })
+        : 0,
+    }))
+    .filter(({ score }) => score >= 50)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3)
+    .map(({ candidate, score }) => ({
+      activityEntryId: candidate.id,
+      user: candidate.user,
+      activity: candidate.activity,
+      datetime: candidate.datetime,
+      quantity: candidate.quantity,
+      score,
+    }));
+}
+
+async function canLinkActivityEntries(userId: string, ownEntryId: string, candidateEntryId: string) {
+  const ownEntry = await prisma.activityEntry.findFirst({
+    where: { id: ownEntryId, userId, deletedAt: null, activityId: { not: null } },
+    include: { activity: true },
+  });
+  if (!ownEntry?.activity) return false;
+
+  const connectionIds = await getAcceptedConnectionIds(userId);
+  const candidateEntry = await prisma.activityEntry.findFirst({
+    where: {
+      id: candidateEntryId,
+      userId: { in: connectionIds },
+      deletedAt: null,
+      activityId: { not: null },
+    },
+    include: { activity: true },
+  });
+  if (!candidateEntry?.activityId || !candidateEntry.activity) return false;
+
+  const visibleActivityIds = await getVisibleActivityIdsForUsers([candidateEntry.userId]);
+  if (!visibleActivityIds.has(candidateEntry.activityId)) return false;
+
+  const score = scoreSharedActivityCandidate({
+    sourceTitle: ownEntry.activity.title,
+    sourceMeasure: ownEntry.activity.measure,
+    sourceEmoji: ownEntry.activity.emoji,
+    sourceDatetime: ownEntry.datetime,
+    candidateTitle: candidateEntry.activity.title,
+    candidateMeasure: candidateEntry.activity.measure,
+    candidateEmoji: candidateEntry.activity.emoji,
+    candidateDatetime: candidateEntry.datetime,
+  });
+
+  return score >= 50;
+}
+
 
 // Get all activities for user
 router.get(
@@ -74,6 +276,7 @@ router.get(
               },
             },
           },
+          sharedActivityEntry: sharedActivityInclude,
         },
         orderBy: { createdAt: "desc" },
       });
@@ -310,7 +513,8 @@ router.post(
         data: { progressCalculatedAt: null },
       });
 
-      res.json(entry);
+      const sharedActivityCandidates = await findSharedActivityCandidates(entry.id, req.user!.id);
+      res.json({ ...entry, entry, sharedActivityCandidates });
     } catch (error) {
       logger.error("Error logging activity:", error);
       res.status(500).json({ error: "Failed to log activity" });
@@ -905,6 +1109,169 @@ router.delete(
     } catch (error) {
       logger.error("Error deleting activity:", error);
       res.status(500).json({ error: "Failed to delete activity" });
+    }
+  }
+);
+
+
+router.get(
+  "/activity-entries/:activityEntryId/shared-candidates",
+  requireAuth,
+  async (
+    req: AuthenticatedRequest,
+    res: Response
+  ): Promise<Response | void> => {
+    try {
+      const candidates = await findSharedActivityCandidates(
+        req.params.activityEntryId,
+        req.user!.id
+      );
+      res.json({ candidates });
+    } catch (error) {
+      logger.error("Error finding shared activity candidates:", error);
+      res.status(500).json({ error: "Failed to find shared activity candidates" });
+    }
+  }
+);
+
+router.post(
+  "/activity-entries/:activityEntryId/shared-link",
+  requireAuth,
+  async (
+    req: AuthenticatedRequest,
+    res: Response
+  ): Promise<Response | void> => {
+    try {
+      const { activityEntryId } = req.params;
+      const { candidateActivityEntryId } = req.body;
+
+      if (!candidateActivityEntryId || typeof candidateActivityEntryId !== "string") {
+        return res.status(400).json({ error: "candidateActivityEntryId is required" });
+      }
+
+      const canLink = await canLinkActivityEntries(
+        req.user!.id,
+        activityEntryId,
+        candidateActivityEntryId
+      );
+      if (!canLink) {
+        return res.status(403).json({ error: "Activity entries cannot be linked" });
+      }
+
+      const [ownLink, candidateLink, candidateEntry] = await Promise.all([
+        prisma.sharedActivityEntry.findUnique({ where: { activityEntryId } }),
+        prisma.sharedActivityEntry.findUnique({ where: { activityEntryId: candidateActivityEntryId } }),
+        prisma.activityEntry.findUnique({ where: { id: candidateActivityEntryId } }),
+      ]);
+
+      if (!candidateEntry) {
+        return res.status(404).json({ error: "Candidate activity entry not found" });
+      }
+
+      if (ownLink && candidateLink && ownLink.sharedActivityId !== candidateLink.sharedActivityId) {
+        return res.status(409).json({ error: "Entries are already linked to different shared activities" });
+      }
+
+      const sharedActivityId =
+        ownLink?.sharedActivityId ||
+        candidateLink?.sharedActivityId ||
+        (await prisma.sharedActivity.create({ data: { createdById: req.user!.id } })).id;
+
+      const duplicateUserLink = await prisma.sharedActivityEntry.findFirst({
+        where: {
+          sharedActivityId,
+          userId: { in: [req.user!.id, candidateEntry.userId] },
+          activityEntryId: { notIn: [activityEntryId, candidateActivityEntryId] },
+        },
+      });
+
+      if (duplicateUserLink) {
+        return res.status(409).json({ error: "User already has an entry in this shared activity" });
+      }
+
+      await prisma.sharedActivityEntry.upsert({
+        where: { activityEntryId },
+        update: { sharedActivityId, userId: req.user!.id },
+        create: { sharedActivityId, activityEntryId, userId: req.user!.id },
+      });
+
+      await prisma.sharedActivityEntry.upsert({
+        where: { activityEntryId: candidateActivityEntryId },
+        update: { sharedActivityId, userId: candidateEntry.userId },
+        create: {
+          sharedActivityId,
+          activityEntryId: candidateActivityEntryId,
+          userId: candidateEntry.userId,
+        },
+      });
+
+      const sharedActivity = await prisma.sharedActivity.findUnique({
+        where: { id: sharedActivityId },
+        include: {
+          entries: {
+            include: {
+              user: { select: { id: true, username: true, name: true, picture: true } },
+              activityEntry: true,
+            },
+          },
+        },
+      });
+
+      await notificationService.createAndProcessNotification({
+        userId: candidateEntry.userId,
+        message: `@${req.user!.username} linked an activity with you`,
+        type: "INFO",
+        relatedId: sharedActivityId,
+        relatedData: {
+          sharedActivityId,
+          activityEntryId,
+          linkedByUsername: req.user!.username,
+          linkedByName: req.user!.name,
+          linkedByPicture: req.user!.picture,
+        },
+      });
+
+      res.json({ sharedActivity });
+    } catch (error) {
+      logger.error("Error linking shared activity:", error);
+      res.status(500).json({ error: "Failed to link shared activity" });
+    }
+  }
+);
+
+router.delete(
+  "/activity-entries/:activityEntryId/shared-link",
+  requireAuth,
+  async (
+    req: AuthenticatedRequest,
+    res: Response
+  ): Promise<Response | void> => {
+    try {
+      const link = await prisma.sharedActivityEntry.findFirst({
+        where: {
+          activityEntryId: req.params.activityEntryId,
+          userId: req.user!.id,
+        },
+      });
+
+      if (!link) {
+        return res.status(404).json({ error: "Shared activity link not found" });
+      }
+
+      await prisma.sharedActivityEntry.delete({ where: { id: link.id } });
+
+      const remaining = await prisma.sharedActivityEntry.count({
+        where: { sharedActivityId: link.sharedActivityId },
+      });
+
+      if (remaining < 2) {
+        await prisma.sharedActivity.delete({ where: { id: link.sharedActivityId } }).catch(() => null);
+      }
+
+      res.json({ success: true });
+    } catch (error) {
+      logger.error("Error unlinking shared activity:", error);
+      res.status(500).json({ error: "Failed to unlink shared activity" });
     }
   }
 );

--- a/apps/backend-node/src/routes/users.ts
+++ b/apps/backend-node/src/routes/users.ts
@@ -595,6 +595,29 @@ usersRouter.post(
                   },
                 },
               },
+              sharedActivityEntry: {
+                include: {
+                  sharedActivity: {
+                    include: {
+                      entries: {
+                        include: {
+                          user: {
+                            select: {
+                              id: true,
+                              username: true,
+                              name: true,
+                              picture: true,
+                            },
+                          },
+                          activityEntry: {
+                            select: { id: true, userId: true, deletedAt: true },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
             },
           },
           // Include coach profile if user is a human coach

--- a/apps/backend-node/src/utils/__tests__/sharedActivities.test.ts
+++ b/apps/backend-node/src/utils/__tests__/sharedActivities.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLikelySharedActivity,
+  normalizeActivityLabel,
+  scoreSharedActivityCandidate,
+} from "../sharedActivities";
+
+describe("shared activity matching", () => {
+  it("normalizes noisy activity labels", () => {
+    expect(normalizeActivityLabel("  Morning-Run!! ")).toBe("morning run");
+  });
+
+  it("scores matching friend activities within the time window", () => {
+    const input = {
+      sourceTitle: "Run",
+      sourceMeasure: "km",
+      sourceEmoji: "🏃",
+      sourceDatetime: new Date("2026-05-06T10:00:00Z"),
+      candidateTitle: "Run",
+      candidateMeasure: "km",
+      candidateEmoji: "🏃",
+      candidateDatetime: new Date("2026-05-06T10:25:00Z"),
+    };
+
+    expect(scoreSharedActivityCandidate(input)).toBeGreaterThanOrEqual(100);
+    expect(isLikelySharedActivity(input)).toBe(true);
+  });
+
+  it("rejects entries that only overlap in time", () => {
+    expect(scoreSharedActivityCandidate({
+      sourceTitle: "Run",
+      sourceMeasure: "km",
+      sourceEmoji: "🏃",
+      sourceDatetime: new Date("2026-05-06T10:00:00Z"),
+      candidateTitle: "Read",
+      candidateMeasure: "pages",
+      candidateEmoji: "📚",
+      candidateDatetime: new Date("2026-05-06T10:10:00Z"),
+    })).toBe(0);
+  });
+
+  it("rejects entries outside the three hour window", () => {
+    expect(scoreSharedActivityCandidate({
+      sourceTitle: "Run",
+      sourceMeasure: "km",
+      sourceEmoji: "🏃",
+      sourceDatetime: new Date("2026-05-06T10:00:00Z"),
+      candidateTitle: "Run",
+      candidateMeasure: "km",
+      candidateEmoji: "🏃",
+      candidateDatetime: new Date("2026-05-06T14:01:00Z"),
+    })).toBe(0);
+  });
+});

--- a/apps/backend-node/src/utils/sharedActivities.ts
+++ b/apps/backend-node/src/utils/sharedActivities.ts
@@ -1,0 +1,64 @@
+export interface SharedActivityMatchInput {
+  sourceTitle: string;
+  sourceMeasure: string;
+  sourceEmoji: string;
+  sourceDatetime: Date;
+  candidateTitle: string;
+  candidateMeasure: string;
+  candidateEmoji: string;
+  candidateDatetime: Date;
+}
+
+export function normalizeActivityLabel(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function scoreSharedActivityCandidate(input: SharedActivityMatchInput): number {
+  const minutesApart = Math.abs(
+    input.sourceDatetime.getTime() - input.candidateDatetime.getTime()
+  ) / 60000;
+
+  if (minutesApart > 180) return 0;
+
+  let score = 0;
+  if (minutesApart <= 30) score += 50;
+  else if (minutesApart <= 90) score += 35;
+  else score += 20;
+
+  const sourceTitle = normalizeActivityLabel(input.sourceTitle);
+  const candidateTitle = normalizeActivityLabel(input.candidateTitle);
+  if (sourceTitle && sourceTitle === candidateTitle) score += 40;
+  else if (
+    sourceTitle &&
+    candidateTitle &&
+    (sourceTitle.includes(candidateTitle) || candidateTitle.includes(sourceTitle))
+  ) {
+    score += 20;
+  }
+
+  if (normalizeActivityLabel(input.sourceMeasure) === normalizeActivityLabel(input.candidateMeasure)) {
+    score += 10;
+  }
+
+  if (input.sourceEmoji && input.sourceEmoji === input.candidateEmoji) {
+    score += 10;
+  }
+
+  const hasSemanticMatch =
+    sourceTitle === candidateTitle ||
+    (sourceTitle &&
+      candidateTitle &&
+      (sourceTitle.includes(candidateTitle) || candidateTitle.includes(sourceTitle))) ||
+    (input.sourceEmoji && input.sourceEmoji === input.candidateEmoji);
+
+  return hasSemanticMatch ? score : 0;
+}
+
+export function isLikelySharedActivity(input: SharedActivityMatchInput): boolean {
+  return scoreSharedActivityCandidate(input) >= 50;
+}

--- a/apps/frontend-vite/src/components/ActivityEntryPhotoCard.tsx
+++ b/apps/frontend-vite/src/components/ActivityEntryPhotoCard.tsx
@@ -62,6 +62,15 @@ interface ActivityEntryPhotoCardProps {
   activityEntry: ActivityEntry & {
     reactions: (Reaction & { user: { username: string } })[];
     comments: (Comment & { user: { username: string; picture: string } })[];
+    sharedActivityEntry?: {
+      sharedActivity?: {
+        entries?: {
+          activityEntryId: string;
+          user: { id: string; username: string | null; name?: string | null; picture?: string | null };
+          activityEntry?: { id: string; userId: string; deletedAt?: Date | null };
+        }[];
+      };
+    } | null;
   };
   user: { username: string; name: string; picture: string; planType: PlanType };
   userPlansProgressData: PlanProgressData[];
@@ -334,6 +343,18 @@ const ActivityEntryPhotoCard: React.FC<ActivityEntryPhotoCardProps> = ({
 
   const trimmedActivityTitle = activity.title.length > 10 ? activity.title.slice(0, 10) + "..." : activity.title;
 
+  const sharedParticipants =
+    activityEntry.sharedActivityEntry?.sharedActivity?.entries
+      ?.filter(
+        (entry) =>
+          entry.activityEntryId !== activityEntry.id && !entry.activityEntry?.deletedAt
+      )
+      ?.map((entry) => entry.user)
+      ?.filter((participant) => participant.username) ?? [];
+  const sharedParticipantLabel = sharedParticipants
+    .map((participant) => `@${participant.username}`)
+    .join(", ");
+
   // Collapsed minimal view for cards without images
   const collapsedCardContent = (
     <div className="relative bg-card/50 backdrop-blur-sm border rounded-2xl overflow-visible p-4 px-5 flex items-center gap-2">
@@ -374,6 +395,11 @@ const ActivityEntryPhotoCard: React.FC<ActivityEntryPhotoCardProps> = ({
         <span className="text-xs text-muted-foreground">
           {activityEntry.quantity} {activity.measure}
         </span>
+        {sharedParticipantLabel && (
+          <span className="text-[11px] text-muted-foreground line-clamp-1">
+            with {sharedParticipantLabel}
+          </span>
+        )}
       </div>
       <div className="absolute top-1.5 right-1.5">
         <Maximize2 className="w-3 h-3 text-muted-foreground opacity-30" />
@@ -582,6 +608,11 @@ const ActivityEntryPhotoCard: React.FC<ActivityEntryPhotoCardProps> = ({
               <span className="font-semibold">
                 {activity.title} – {activityEntry.quantity} {activity.measure}
               </span>
+              {sharedParticipantLabel && (
+                <span className="text-xs text-muted-foreground">
+                  with {sharedParticipantLabel}
+                </span>
+              )}
               <span className="text-xs text-muted-foreground">
                 {getFormattedDate(activityEntry.datetime)}{" "}
                 {activityEntry.timezone && `– 📍 ${activityEntry.timezone}`}

--- a/apps/frontend-vite/src/components/ActivityPhotoUploader.tsx
+++ b/apps/frontend-vite/src/components/ActivityPhotoUploader.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import PhotoUploader from "@/components/ui/photo-uploader";
 import { TextAreaWithVoice } from "@/components/ui/text-area-with-voice";
+import type { SharedActivityCandidate } from "@/contexts/activities/types";
 import { useActivities } from "@/contexts/activities/useActivities";
 import { useNotifications } from "@/hooks/useNotifications";
 import { Info, Loader2 } from "lucide-react";
@@ -18,7 +19,7 @@ interface ActivityPhotoUploaderProps {
     quantity: number;
   };
   onClose: () => void;
-  onSuccess: (entryId: string) => void;
+  onSuccess: (entryId: string, candidates: SharedActivityCandidate[]) => void;
   open: boolean;
 }
 
@@ -36,7 +37,7 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
 
   const handleLogActivity = async () => {
     try {
-      const entry = await submitActivity({
+      const response = await submitActivity({
         activityId: activityData.activityId,
         datetime: activityData.datetime,
         quantity: activityData.quantity,
@@ -44,12 +45,12 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
         photo: selectedFile || undefined,
       });
 
-      if (!entry?.id) {
+      if (!response.entry?.id) {
         throw new Error("No entry ID returned");
       }
 
       addToNotificationCount(1, "profile");
-      onSuccess(entry.id);
+      onSuccess(response.entry.id, response.sharedActivityCandidates || []);
     } catch (error: any) {
       console.error("Error logging activity:", error);
       toast.error("Failed to log activity. Please try again.");

--- a/apps/frontend-vite/src/components/SharedActivityPrompt.tsx
+++ b/apps/frontend-vite/src/components/SharedActivityPrompt.tsx
@@ -1,0 +1,63 @@
+import type { SharedActivityCandidate } from "@/contexts/activities/types";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import AppleLikePopover from "./AppleLikePopover";
+
+interface SharedActivityPromptProps {
+  open: boolean;
+  candidates: SharedActivityCandidate[];
+  onConfirm: (candidateActivityEntryId: string) => Promise<void>;
+  onDismiss: () => void;
+}
+
+export default function SharedActivityPrompt({
+  open,
+  candidates,
+  onConfirm,
+  onDismiss,
+}: SharedActivityPromptProps) {
+  const candidate = candidates[0];
+
+  if (!candidate) return null;
+
+  const username = candidate.user.username || "your friend";
+
+  return (
+    <AppleLikePopover open={open} onClose={onDismiss}>
+      <div className="space-y-4">
+        <div>
+          <h2 className="text-2xl font-bold">Did you do this together?</h2>
+          <p className="text-muted-foreground mt-2">
+            Looks like @{username} logged a similar {candidate.activity.emoji}{" "}
+            {candidate.activity.title} around the same time.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3 rounded-2xl border bg-card/60 p-3">
+          <Avatar className="h-10 w-10">
+            <AvatarImage src={candidate.user.picture || ""} />
+            <AvatarFallback>{username[0]?.toUpperCase()}</AvatarFallback>
+          </Avatar>
+          <div>
+            <div className="font-semibold">@{username}</div>
+            <div className="text-sm text-muted-foreground">
+              {candidate.quantity} {candidate.activity.measure} · score {candidate.score}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-2">
+          <Button
+            className="flex-1"
+            onClick={() => onConfirm(candidate.activityEntryId)}
+          >
+            Yes, link us
+          </Button>
+          <Button className="flex-1" variant="outline" onClick={onDismiss}>
+            Not this time
+          </Button>
+        </div>
+      </div>
+    </AppleLikePopover>
+  );
+}

--- a/apps/frontend-vite/src/contexts/activities/provider.tsx
+++ b/apps/frontend-vite/src/contexts/activities/provider.tsx
@@ -8,11 +8,19 @@ import React from "react";
 import { toast } from "react-hot-toast";
 import { type TimelineData } from "../timeline/service";
 import { type HydratedUser } from "../users/service";
-import { getActivities, getActivitiyEntries, deleteAchievementPost } from "./service";
+import {
+  deleteAchievementPost,
+  getActivities,
+  getActivitiyEntries,
+  getSharedActivityCandidates,
+  linkSharedActivity,
+  unlinkSharedActivity,
+} from "./service";
 import {
   ActivitiesContext,
   type ActivitiesContextType,
   type ActivityLogData,
+  type LogActivityResponse,
   type ReturnedActivitiesType,
   type ReturnedActivityEntriesType,
 } from "./types";
@@ -67,7 +75,8 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
       const response = await api.post("/activities/log-activity", formData);
       return response.data;
     },
-    onSuccess: async (entry, variables) => {
+    onSuccess: async (response: LogActivityResponse, variables) => {
+      const entry = response.entry;
       queryClient.refetchQueries({ queryKey: ["current-user"] });
       queryClient.setQueryData(
         ["activity-entries"],
@@ -654,6 +663,53 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
     },
   });
 
+
+  const getSharedActivityCandidatesMutation = async (activityEntryId: string) => {
+    return getSharedActivityCandidates(api, activityEntryId);
+  };
+
+  const linkSharedActivityMutation = useMutation({
+    mutationFn: async (data: {
+      activityEntryId: string;
+      candidateActivityEntryId: string;
+    }) => {
+      await linkSharedActivity(
+        api,
+        data.activityEntryId,
+        data.candidateActivityEntryId
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["activity-entries"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      queryClient.invalidateQueries({ queryKey: ["user"] });
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+      toast.success("Activity linked with your friend!");
+    },
+    onError: (error) => {
+      const customErrorMessage = `Failed to link activity`;
+      handleQueryError(error, customErrorMessage);
+      toast.error(customErrorMessage);
+    },
+  });
+
+  const unlinkSharedActivityMutation = useMutation({
+    mutationFn: async (activityEntryId: string) => {
+      await unlinkSharedActivity(api, activityEntryId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["activity-entries"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      queryClient.invalidateQueries({ queryKey: ["user"] });
+      toast.success("Joint activity removed");
+    },
+    onError: (error) => {
+      const customErrorMessage = `Failed to unlink activity`;
+      handleQueryError(error, customErrorMessage);
+      toast.error(customErrorMessage);
+    },
+  });
+
   const context: ActivitiesContextType = {
     activities: activitiesQuery.data || [],
     activityEntries: activitiesEntriesQuery.data || [],
@@ -686,6 +742,10 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
     removeCommentFromAchievement: removeCommentFromAchievementMutation.mutateAsync,
     deleteAchievementPost: deleteAchievementPostMutation.mutateAsync,
     isDeletingAchievementPost: deleteAchievementPostMutation.isPending,
+
+    getSharedActivityCandidates: getSharedActivityCandidatesMutation,
+    linkSharedActivity: linkSharedActivityMutation.mutateAsync,
+    unlinkSharedActivity: unlinkSharedActivityMutation.mutateAsync,
 
     updateActivityEntryPhoto: updateActivityEntryPhotoMutation.mutateAsync,
     deleteActivityEntryPhoto: deleteActivityEntryPhotoMutation.mutateAsync,

--- a/apps/frontend-vite/src/contexts/activities/service.ts
+++ b/apps/frontend-vite/src/contexts/activities/service.ts
@@ -14,6 +14,33 @@ export type ActivityEntryWithRelations = Prisma.ActivityEntryGetPayload<{
         };
       };
     };
+    sharedActivityEntry: {
+      include: {
+        sharedActivity: {
+          include: {
+            entries: {
+              include: {
+                user: {
+                  select: {
+                    id: true;
+                    username: true;
+                    name: true;
+                    picture: true;
+                  };
+                };
+                activityEntry: {
+                  select: {
+                    id: true;
+                    userId: true;
+                    deletedAt: true;
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
     reactions: {
       include: {
         user: {
@@ -45,4 +72,34 @@ export async function deleteAchievementPost(
   achievementPostId: string
 ) {
   await api.delete(`/achievements/${achievementPostId}`);
+}
+
+
+export async function getSharedActivityCandidates(
+  api: AxiosInstance,
+  activityEntryId: string
+) {
+  const response = await api.get(
+    `/activities/activity-entries/${activityEntryId}/shared-candidates`
+  );
+  return response.data.candidates;
+}
+
+export async function linkSharedActivity(
+  api: AxiosInstance,
+  activityEntryId: string,
+  candidateActivityEntryId: string
+) {
+  const response = await api.post(
+    `/activities/activity-entries/${activityEntryId}/shared-link`,
+    { candidateActivityEntryId }
+  );
+  return response.data;
+}
+
+export async function unlinkSharedActivity(api: AxiosInstance, activityEntryId: string) {
+  const response = await api.delete(
+    `/activities/activity-entries/${activityEntryId}/shared-link`
+  );
+  return response.data;
 }

--- a/apps/frontend-vite/src/contexts/activities/types.ts
+++ b/apps/frontend-vite/src/contexts/activities/types.ts
@@ -6,6 +6,25 @@ export type ReturnedActivityEntriesType = Awaited<
   ReturnType<typeof getActivitiyEntries>
 >;
 export type ReturnedActivitiesType = Awaited<ReturnType<typeof getActivities>>;
+export interface SharedActivityCandidate {
+  activityEntryId: string;
+  user: {
+    id: string;
+    username: string | null;
+    name?: string | null;
+    picture?: string | null;
+  };
+  activity: Activity;
+  datetime: string;
+  quantity: number;
+  score: number;
+}
+
+export interface LogActivityResponse {
+  entry: ActivityEntry;
+  sharedActivityCandidates: SharedActivityCandidate[];
+}
+
 export interface ActivityLogData {
   activityId: string;
   datetime: Date;
@@ -20,7 +39,7 @@ export interface ActivitiesContextType {
   isLoadingActivities: boolean;
   isLoadingActivityEntries: boolean;
 
-  logActivity: (data: ActivityLogData) => Promise<ActivityEntry>;
+  logActivity: (data: ActivityLogData) => Promise<LogActivityResponse>;
   isLoggingActivity: boolean;
 
   upsertActivity: (data: {
@@ -83,6 +102,15 @@ export interface ActivitiesContextType {
     userUsername: string;
   }) => Promise<void>;
   isDeletingAchievementPost: boolean;
+
+  getSharedActivityCandidates: (
+    activityEntryId: string
+  ) => Promise<SharedActivityCandidate[]>;
+  linkSharedActivity: (data: {
+    activityEntryId: string;
+    candidateActivityEntryId: string;
+  }) => Promise<void>;
+  unlinkSharedActivity: (activityEntryId: string) => Promise<void>;
 
   updateActivityEntryPhoto: (data: {
     activityEntryId: string;

--- a/apps/frontend-vite/src/routes/add.tsx
+++ b/apps/frontend-vite/src/routes/add.tsx
@@ -7,8 +7,9 @@ import {
   type DifficultyLevel,
 } from "@/components/DifficultyLogPopover";
 import { MetricsLogPopover } from "@/components/MetricsLogPopover";
+import SharedActivityPrompt from "@/components/SharedActivityPrompt";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { ActivityLogData } from "@/contexts/activities/types";
+import type { ActivityLogData, SharedActivityCandidate } from "@/contexts/activities/types";
 import { useActivities } from "@/contexts/activities/useActivities";
 import { useMetrics } from "@/contexts/metrics";
 import { usePlans } from "@/contexts/plans";
@@ -28,6 +29,7 @@ function LogPage() {
     activityEntries,
     isLoadingActivities,
     upsertActivityEntry,
+    linkSharedActivity,
   } = useActivities();
   const { metrics } = useMetrics();
   const { plans } = usePlans();
@@ -56,6 +58,8 @@ function LogPage() {
   const [currentActivityLogData, setCurrentActivityLogData] =
     useState<ActivityLogData | null>(null);
   const [currentEntryId, setCurrentEntryId] = useState<string | null>(null);
+  const [sharedActivityCandidates, setSharedActivityCandidates] = useState<SharedActivityCandidate[]>([]);
+  const [showSharedActivityPrompt, setShowSharedActivityPrompt] = useState(false);
 
   const handleActivityLogSubmit = useCallback(
     (data: ActivityLogData) => {
@@ -85,9 +89,7 @@ function LogPage() {
     setEditingActivity(activity);
   };
 
-  const handleActivityLoggedAndPhotoSkippedOrDone = (entryId: string) => {
-    setShowPhotoUploader(false);
-    setCurrentEntryId(entryId);
+  const continuePostLogFlow = (entryId: string) => {
 
     // Show difficulty popover only for coached plans and if activity was within the past 48 hours
     const isWithin48Hours =
@@ -106,6 +108,39 @@ function LogPage() {
       // Skip to metrics check if not in coached plan or activity is older than 48h
       handleDifficultyDone();
     }
+  };
+
+  const handleActivityLoggedAndPhotoSkippedOrDone = (
+    entryId: string,
+    candidates: SharedActivityCandidate[]
+  ) => {
+    setShowPhotoUploader(false);
+    setCurrentEntryId(entryId);
+    setSharedActivityCandidates(candidates);
+
+    if (candidates.length > 0) {
+      setShowSharedActivityPrompt(true);
+      return;
+    }
+
+    continuePostLogFlow(entryId);
+  };
+
+  const handleSharedActivityPromptDone = () => {
+    setShowSharedActivityPrompt(false);
+    setSharedActivityCandidates([]);
+    if (currentEntryId) {
+      continuePostLogFlow(currentEntryId);
+    }
+  };
+
+  const handleLinkSharedActivity = async (candidateActivityEntryId: string) => {
+    if (!currentEntryId) return;
+    await linkSharedActivity({
+      activityEntryId: currentEntryId,
+      candidateActivityEntryId,
+    });
+    handleSharedActivityPromptDone();
   };
 
   const handleDifficultySubmit = async (difficulty: DifficultyLevel) => {
@@ -210,6 +245,13 @@ function LogPage() {
           )}
         </>
       )}
+
+      <SharedActivityPrompt
+        open={showSharedActivityPrompt}
+        candidates={sharedActivityCandidates}
+        onConfirm={handleLinkSharedActivity}
+        onDismiss={handleSharedActivityPromptDone}
+      />
 
       {/* Difficulty Popover - shown after activity is logged (within 48h) */}
       <DifficultyLogPopover

--- a/packages/prisma/migrations/20260506174500_add_shared_activities/migration.sql
+++ b/packages/prisma/migrations/20260506174500_add_shared_activities/migration.sql
@@ -1,0 +1,53 @@
+CREATE TABLE "public"."shared_activities" (
+  "id" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "createdById" TEXT NOT NULL,
+  CONSTRAINT "shared_activities_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "public"."shared_activity_entries" (
+  "id" TEXT NOT NULL,
+  "sharedActivityId" TEXT NOT NULL,
+  "activityEntryId" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "confirmedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "shared_activity_entries_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "shared_activity_entries_activityEntryId_key"
+  ON "public"."shared_activity_entries"("activityEntryId");
+
+CREATE UNIQUE INDEX "shared_activity_entries_sharedActivityId_userId_key"
+  ON "public"."shared_activity_entries"("sharedActivityId", "userId");
+
+CREATE INDEX "shared_activities_createdById_idx"
+  ON "public"."shared_activities"("createdById");
+
+CREATE INDEX "shared_activity_entries_sharedActivityId_idx"
+  ON "public"."shared_activity_entries"("sharedActivityId");
+
+CREATE INDEX "shared_activity_entries_userId_idx"
+  ON "public"."shared_activity_entries"("userId");
+
+CREATE INDEX "activity_entries_userId_datetime_deletedAt_idx"
+  ON "public"."activity_entries"("userId", "datetime", "deletedAt");
+
+ALTER TABLE "public"."shared_activities"
+  ADD CONSTRAINT "shared_activities_createdById_fkey"
+  FOREIGN KEY ("createdById") REFERENCES "public"."users"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."shared_activity_entries"
+  ADD CONSTRAINT "shared_activity_entries_sharedActivityId_fkey"
+  FOREIGN KEY ("sharedActivityId") REFERENCES "public"."shared_activities"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."shared_activity_entries"
+  ADD CONSTRAINT "shared_activity_entries_activityEntryId_fkey"
+  FOREIGN KEY ("activityEntryId") REFERENCES "public"."activity_entries"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."shared_activity_entries"
+  ADD CONSTRAINT "shared_activity_entries_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "public"."users"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -94,6 +94,8 @@ model User {
 
   // Achievement posts
   achievementPosts AchievementPost[]
+  sharedActivitiesCreated SharedActivity[]      @relation("SharedActivityCreatedBy")
+  sharedActivityEntries   SharedActivityEntry[]
 
   // Level celebration tracking
   celebratedLevelThreshold Int?
@@ -174,8 +176,10 @@ model ActivityEntry {
   user      User       @relation(fields: [userId], references: [id], onDelete: Cascade)
   reactions Reaction[]
   comments  Comment[]
+  sharedActivityEntry SharedActivityEntry?
 
   @@index([userId, deletedAt])
+  @@index([userId, datetime, deletedAt])
   @@index([deletedAt, createdAt])
   @@index([activityId])
   @@index([createdAt])
@@ -265,6 +269,38 @@ model AchievementImage {
 
   @@index([achievementPostId, sortOrder])
   @@map("achievement_images")
+  @@schema("public")
+}
+
+
+model SharedActivity {
+  id          String                @id @default(cuid())
+  createdAt   DateTime              @default(now())
+  createdById String
+
+  createdBy User                  @relation("SharedActivityCreatedBy", fields: [createdById], references: [id], onDelete: Cascade)
+  entries   SharedActivityEntry[]
+
+  @@index([createdById])
+  @@map("shared_activities")
+  @@schema("public")
+}
+
+model SharedActivityEntry {
+  id               String   @id @default(cuid())
+  sharedActivityId String
+  activityEntryId  String   @unique
+  userId           String
+  confirmedAt      DateTime @default(now())
+
+  sharedActivity SharedActivity @relation(fields: [sharedActivityId], references: [id], onDelete: Cascade)
+  activityEntry  ActivityEntry  @relation(fields: [activityEntryId], references: [id], onDelete: Cascade)
+  user           User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([sharedActivityId, userId])
+  @@index([sharedActivityId])
+  @@index([userId])
+  @@map("shared_activity_entries")
   @@schema("public")
 }
 


### PR DESCRIPTION
## Summary
- Add Strava-style joint activity linking between friends
- Suggest likely joint activities after a user logs their own activity
- Add confirm/dismiss prompt and show `with @friend` on linked activity cards
- Add Prisma models/migration and matching helper tests

## Behavior
- Candidates are limited to accepted friends, visible activity entries, unlinked entries, and likely matches within a 3-hour window
- Linking verifies ownership, friend connection, visibility, and matching score server-side
- Existing `POST /activities/log-activity` response remains backward-compatible while adding `entry` and `sharedActivityCandidates`

## Verification
- `pnpm --filter @tsw/prisma db:generate`
- `pnpm exec vitest run src/utils/__tests__/sharedActivities.test.ts --bail=1`
- `cd apps/backend-node && pnpm build`
- `cd apps/frontend-vite && pnpm build`
- `git diff --check`
