### PR TITLE
feat: group joint activity cards in timeline

### DIFF
--- a/apps/backend-node/src/routes/users.ts
+++ b/apps/backend-node/src/routes/users.ts
@@ -856,6 +856,41 @@ usersRouter.get(
               },
             },
           },
+          sharedActivityEntry: {
+            include: {
+              sharedActivity: {
+                include: {
+                  entries: {
+                    where: {
+                      userId: { in: userIds },
+                      activityEntry: {
+                        deletedAt: null,
+                        activityId: { in: validActivityIds },
+                      },
+                    },
+                    include: {
+                      user: {
+                        select: {
+                          id: true,
+                          username: true,
+                          name: true,
+                          picture: true,
+                        },
+                      },
+                      activityEntry: {
+                        select: {
+                          id: true,
+                          userId: true,
+                          deletedAt: true,
+                          activityId: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
       });
 

--- a/apps/frontend-vite/src/components/SharedActivityEntryGroupCard.tsx
+++ b/apps/frontend-vite/src/components/SharedActivityEntryGroupCard.tsx
@@ -1,0 +1,113 @@
+import type { TimelineActivityEntry, TimelineUser } from "@/contexts/timeline/service";
+import { cn } from "@/lib/utils";
+import { type Activity } from "@tsw/prisma";
+import { format } from "date-fns";
+import { Users } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
+
+type SharedActivityGroupEntry = {
+  entry: TimelineActivityEntry;
+  activity: Activity;
+  user: TimelineUser;
+};
+
+interface SharedActivityEntryGroupCardProps {
+  items: SharedActivityGroupEntry[];
+  className?: string;
+  onUserClick?: (username: string) => void;
+}
+
+export default function SharedActivityEntryGroupCard({
+  items,
+  className,
+  onUserClick,
+}: SharedActivityEntryGroupCardProps) {
+  if (items.length === 0) return null;
+
+  const sortedItems = [...items].sort(
+    (a, b) =>
+      new Date(b.entry.datetime).getTime() - new Date(a.entry.datetime).getTime()
+  );
+  const anchor = sortedItems[0];
+  const imageItem = sortedItems.find((item) => {
+    if (!item.entry.imageUrl) return false;
+    return !item.entry.imageExpiresAt || new Date(item.entry.imageExpiresAt) > new Date();
+  });
+  const participantLabel = sortedItems
+    .map((item) => `@${item.user.username}`)
+    .join(" · ");
+
+  return (
+    <div className={cn("bg-card border rounded-2xl overflow-hidden", className)}>
+      {imageItem?.entry.imageUrl && (
+        <div className="p-4 pb-0">
+          <img
+            src={imageItem.entry.imageUrl}
+            alt={imageItem.activity.title}
+            className="w-full max-h-[360px] object-cover rounded-2xl border border-white/20"
+          />
+        </div>
+      )}
+
+      <div className="p-4 space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="flex -space-x-2">
+            {sortedItems.slice(0, 4).map(({ user }) => (
+              <Avatar
+                key={user.id}
+                className="h-9 w-9 border-2 border-card cursor-pointer"
+                onClick={() => user.username && onUserClick?.(user.username)}
+              >
+                <AvatarImage src={user.picture || ""} alt={user.name || ""} />
+                <AvatarFallback>{(user.name || user.username || "U")[0]}</AvatarFallback>
+              </Avatar>
+            ))}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <Users className="h-4 w-4 text-muted-foreground" />
+              <span>Joint activity</span>
+            </div>
+            <div className="text-xs text-muted-foreground truncate">
+              {participantLabel}
+            </div>
+          </div>
+          <div className="text-xs text-muted-foreground whitespace-nowrap">
+            {format(new Date(anchor.entry.datetime), "MMM d")}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          {sortedItems.map(({ entry, activity, user }) => (
+            <div
+              key={entry.id}
+              className="flex items-center justify-between gap-3 rounded-xl bg-muted/40 px-3 py-2"
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-2xl">{activity.emoji}</span>
+                <div className="min-w-0">
+                  <div className="text-sm font-medium truncate">
+                    {activity.title}
+                  </div>
+                  <button
+                    className="text-xs text-muted-foreground hover:underline"
+                    onClick={() => user.username && onUserClick?.(user.username)}
+                  >
+                    @{user.username}
+                  </button>
+                </div>
+              </div>
+              <div className="text-sm font-semibold whitespace-nowrap">
+                {entry.quantity} {activity.measure}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          Linked from separate logs. Reactions and comments stay on each original activity for now.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend-vite/src/components/TimelineRenderer.tsx
+++ b/apps/frontend-vite/src/components/TimelineRenderer.tsx
@@ -1,6 +1,7 @@
 import { useApiWithAuth } from "@/api";
 import ActivityEntryPhotoCard from "@/components/ActivityEntryPhotoCard";
 import AchievementPostCard from "@/components/AchievementPostCard";
+import SharedActivityEntryGroupCard from "@/components/SharedActivityEntryGroupCard";
 import { useActivities } from "@/contexts/activities/useActivities";
 import { usePlans } from "@/contexts/plans";
 import { useTimeline } from "@/contexts/timeline/useTimeline";
@@ -25,7 +26,13 @@ import toast from "react-hot-toast";
 import {
   type TimelineActivityEntry,
   type TimelineAchievementPost,
+  type TimelineUser,
 } from "@/contexts/timeline/service";
+import {
+  getGroupedFeedItemDate,
+  groupSharedActivityItems,
+  type GroupedFeedItem,
+} from "@/utils/sharedActivityGrouping";
 
 interface HumanCoach {
   id: string;
@@ -206,7 +213,6 @@ const TimelineRenderer: React.FC<{
       items.push({ type: "activity", data: entry });
     });
 
-    console.log("timelineData.achievementPosts", timelineData.achievementPosts);
     // Add achievement posts
     (timelineData.achievementPosts || []).forEach((post) => {
       items.push({ type: "achievement", data: post });
@@ -228,44 +234,36 @@ const TimelineRenderer: React.FC<{
     return items;
   }, [timelineData]);
 
+  const groupedTimelineItems = useMemo<
+    Array<GroupedFeedItem<TimelineActivityEntry, TimelineAchievementPost>>
+  >(
+    () =>
+      groupSharedActivityItems<TimelineActivityEntry, TimelineAchievementPost>(
+        mergedTimelineItems
+      ),
+    [mergedTimelineItems]
+  );
+
   // Check if there will be a divider shown (new posts exist AND we have a lastViewedTimelineAt)
   const willShowDivider = useMemo(() => {
-    if (!lastViewedTimelineAt || !mergedTimelineItems.length) return false;
+    if (!lastViewedTimelineAt || !groupedTimelineItems.length) return false;
     const lastViewed = new Date(lastViewedTimelineAt);
 
     // Check if there are any items newer than lastViewed
-    const hasNewItems = mergedTimelineItems.some((item) => {
-      const itemDate =
-        item.type === "activity"
-          ? new Date(item.data.datetime)
-          : new Date(item.data.createdAt);
-      return itemDate > lastViewed;
-    });
+    const hasNewItems = groupedTimelineItems.some((item) => getGroupedFeedItemDate(item) > lastViewed);
 
     // Check if there are any items older than or equal to lastViewed (where divider would appear)
-    const hasOldItems = mergedTimelineItems.some((item) => {
-      const itemDate =
-        item.type === "activity"
-          ? new Date(item.data.datetime)
-          : new Date(item.data.createdAt);
-      return itemDate <= lastViewed;
-    });
+    const hasOldItems = groupedTimelineItems.some((item) => getGroupedFeedItemDate(item) <= lastViewed);
 
     return hasNewItems && hasOldItems;
-  }, [lastViewedTimelineAt, mergedTimelineItems]);
+  }, [lastViewedTimelineAt, groupedTimelineItems]);
 
   // Count new items for badge display
   const newItemsCount = useMemo(() => {
-    if (!lastViewedTimelineAt || !mergedTimelineItems.length) return 0;
+    if (!lastViewedTimelineAt || !groupedTimelineItems.length) return 0;
     const lastViewed = new Date(lastViewedTimelineAt);
-    return mergedTimelineItems.filter((item) => {
-      const itemDate =
-        item.type === "activity"
-          ? new Date(item.data.datetime)
-          : new Date(item.data.createdAt);
-      return itemDate > lastViewed;
-    }).length;
-  }, [lastViewedTimelineAt, mergedTimelineItems]);
+    return groupedTimelineItems.filter((item) => getGroupedFeedItemDate(item) > lastViewed).length;
+  }, [lastViewedTimelineAt, groupedTimelineItems]);
 
   // Update last viewed timestamp when user views timeline
   // If divider exists: wait until user scrolls to it
@@ -512,7 +510,7 @@ const TimelineRenderer: React.FC<{
           Friend&apos;s last activities
         </h2>
         <span className="text-sm text-muted-foreground">
-          ({mergedTimelineItems.length})
+          ({groupedTimelineItems.length})
         </span>
         {newItemsCount > 0 && (
           <Badge variant="destructive" className="text-xs">
@@ -533,42 +531,60 @@ const TimelineRenderer: React.FC<{
             ? new Date(lastViewedTimelineAt)
             : null;
 
-          // Check if there are any new items (newer than lastViewed)
           const hasNewEntries =
             lastViewed &&
-            mergedTimelineItems.some((item) => {
-              const itemDate =
-                item.type === "activity"
-                  ? new Date(item.data.datetime)
-                  : new Date(item.data.createdAt);
-              return itemDate > lastViewed;
-            });
+            groupedTimelineItems.some(
+              (item) => getGroupedFeedItemDate(item) > lastViewed
+            );
 
-          // count the timeline items types
-          console.log(
-            "timeline items types",
-            mergedTimelineItems.reduce((acc: Record<string, number>, item: TimelineItem) => {
-              acc[item.type] = (acc[item.type] || 0) + 1;
-              return acc;
-            }, {} as Record<string, number>)
-          );
-          return mergedTimelineItems.map((item, index) => {
+          const allActivities = [
+            ...(timelineData?.recommendedActivities || []),
+            ...activities,
+          ];
+          const allUsers = [
+            ...(timelineData?.recommendedUsers || []),
+            currentUser,
+          ];
+
+          const getEntryDisplayData = (entry: TimelineActivityEntry) => {
+            const activity = allActivities?.find(
+              (a: Activity) => a.id === entry.activityId
+            );
+            const user = allUsers?.find((u: any) => u?.id === activity?.userId);
+            if (!activity || !user || user.username === null) return null;
+
+            const timelineUser = timelineData?.recommendedUsers?.find(
+              (u) => u.id === user.id
+            );
+            const userPlansProgress =
+              timelineUser?.plans
+                ?.filter((plan) =>
+                  plan.activities?.some((a) => a.id === activity?.id)
+                )
+                .map((plan) => plan.progress) || [];
+
+            return {
+              entry,
+              activity,
+              user: user as TimelineUser,
+              userPlansProgress,
+            };
+          };
+
+          return groupedTimelineItems.map((item) => {
+            const itemDate = getGroupedFeedItemDate(item);
+            const shouldShowDivider =
+              !dividerShown &&
+              hasNewEntries &&
+              lastViewed &&
+              itemDate <= lastViewed;
+
+            if (shouldShowDivider) {
+              dividerShown = true;
+            }
+
             if (item.type === "achievement") {
-              // Render achievement post
               const post = item.data;
-
-              // Check if we should show the divider before this post
-              const postDatetime = new Date(post.createdAt);
-              const shouldShowDivider =
-                !dividerShown &&
-                hasNewEntries &&
-                lastViewed &&
-                postDatetime <= lastViewed;
-
-              if (shouldShowDivider) {
-                dividerShown = true;
-              }
-
               return (
                 <React.Fragment key={`achievement-${post.id}`}>
                   {shouldShowDivider && <AllCaughtUpDivider ref={dividerRef} />}
@@ -591,111 +607,174 @@ const TimelineRenderer: React.FC<{
                   </div>
                 </React.Fragment>
               );
-            } else {
-              // Render activity entry
-              const entry = item.data;
-              const allActivities = [
-                ...(timelineData?.recommendedActivities || []),
-                ...activities,
-              ];
-              const activity = allActivities?.find(
-                (a: Activity) => a.id === entry.activityId
-              );
-              const allUsers = [
-                ...(timelineData?.recommendedUsers || []),
-                currentUser,
-              ];
-              const user = allUsers?.find(
-                (u: any) => u.id === activity?.userId
-              );
-              if (!activity || !user || user.username === null) return null;
+            }
 
-              const timelineUser = timelineData?.recommendedUsers?.find(
-                (u) => u.id === user.id
-              );
-              const userPlansProgress =
-                timelineUser?.plans
-                  ?.filter((plan) =>
-                    plan.activities?.some((a) => a.id === activity?.id)
-                  )
-                  .map((plan) => plan.progress) || [];
-
-              const hasImageExpired =
-                entry.imageExpiresAt &&
-                new Date(entry.imageExpiresAt) < new Date();
-              const hasImage = entry.imageUrl && !hasImageExpired;
-              const isCollapsed = collapsedEntries.has(entry.id);
-
-              // Check if we should show the divider before this entry
-              const entryDatetime = new Date(entry.datetime);
-              const shouldShowDivider =
-                !dividerShown &&
-                hasNewEntries &&
-                lastViewed &&
-                entryDatetime <= lastViewed;
-
-              if (shouldShowDivider) {
-                dividerShown = true;
+            if (item.type === "sharedActivity") {
+              const displayItems = item.entries
+                .map(getEntryDisplayData)
+                .filter(Boolean) as NonNullable<ReturnType<typeof getEntryDisplayData>>[];
+              if (displayItems.length < 2) {
+                return (
+                  <React.Fragment key={`shared-activity-fallback-${item.sharedActivityId}`}>
+                    {shouldShowDivider && <AllCaughtUpDivider ref={dividerRef} />}
+                    {displayItems.map(({ entry, activity, user, userPlansProgress }) => (
+                      <div key={entry.id} className="col-span-2 sm:col-span-4">
+                        <ActivityEntryPhotoCard
+                          activity={activity}
+                          activityEntry={entry as any}
+                          user={
+                            user as {
+                              username: string;
+                              name: string;
+                              picture: string;
+                              planType: PlanType;
+                            }
+                          }
+                          userPlansProgressData={userPlansProgress}
+                        />
+                      </div>
+                    ))}
+                  </React.Fragment>
+                );
               }
 
+              const isHighlighted = item.entries.some(
+                (entry) => highlightedEntryId === entry.id
+              );
+
               return (
-                <React.Fragment key={`activity-${entry.id}`}>
+                <React.Fragment key={`shared-activity-${item.sharedActivityId}`}>
                   {shouldShowDivider && <AllCaughtUpDivider ref={dividerRef} />}
                   <div
                     ref={(el) => {
-                      if (el) {
-                        entryRefs.current.set(entry.id, el);
-                      } else {
-                        entryRefs.current.delete(entry.id);
-                      }
+                      item.entries.forEach((entry) => {
+                        if (el) {
+                          entryRefs.current.set(entry.id, el);
+                        } else {
+                          entryRefs.current.delete(entry.id);
+                        }
+                      });
                     }}
-                    className={`transition-all duration-500 ${
-                      highlightedEntryId === entry.id
-                        ? cn(
-                            "ring-4 ring-opacity-50 rounded-2xl",
-                            variants.ring
-                          )
+                    className={`col-span-2 sm:col-span-4 transition-all duration-500 ${
+                      isHighlighted
+                        ? cn("ring-4 ring-opacity-50 rounded-2xl", variants.ring)
                         : ""
-                    } ${
-                      hasImage
-                        ? "col-span-2 sm:col-span-4"
-                        : isCollapsed
-                        ? "col-span-1"
-                        : "col-span-2 sm:col-span-4"
                     }`}
                   >
-                    <ActivityEntryPhotoCard
-                      key={entry.id}
-                      activity={activity}
-                      activityEntry={entry as any}
-                      user={
-                        user as {
-                          username: string;
-                          name: string;
-                          picture: string;
-                          planType: PlanType;
-                        }
+                    <SharedActivityEntryGroupCard
+                      items={displayItems}
+                      onUserClick={(username) =>
+                        navigate({
+                          to: `/profile/$username`,
+                          params: { username },
+                        })
                       }
-                      userPlansProgressData={userPlansProgress}
-                      isCollapsed={isCollapsed}
-                      onToggleCollapse={() => toggleEntryCollapse(entry.id)}
-                      onAvatarClick={() => {
-                        navigate({
-                          to: `/profile/$username`,
-                          params: { username: user?.username || "" },
-                        });
-                      }}
-                      onUsernameClick={() => {
-                        navigate({
-                          to: `/profile/$username`,
-                          params: { username: user?.username || "" },
-                        });
-                      }}
                     />
+                    <details className="mt-2 rounded-2xl border bg-card/60 p-3">
+                      <summary className="cursor-pointer text-sm font-medium text-muted-foreground">
+                        View individual activity cards
+                      </summary>
+                      <div className="mt-3 space-y-3">
+                        {displayItems.map(({ entry, activity, user, userPlansProgress }) => (
+                          <ActivityEntryPhotoCard
+                            key={entry.id}
+                            activity={activity}
+                            activityEntry={entry as any}
+                            user={
+                              user as {
+                                username: string;
+                                name: string;
+                                picture: string;
+                                planType: PlanType;
+                              }
+                            }
+                            userPlansProgressData={userPlansProgress}
+                            isCollapsed={false}
+                            onAvatarClick={() => {
+                              navigate({
+                                to: `/profile/$username`,
+                                params: { username: user?.username || "" },
+                              });
+                            }}
+                            onUsernameClick={() => {
+                              navigate({
+                                to: `/profile/$username`,
+                                params: { username: user?.username || "" },
+                              });
+                            }}
+                          />
+                        ))}
+                      </div>
+                    </details>
                   </div>
                 </React.Fragment>
               );
             }
+
+            const entry = item.data;
+            const displayData = getEntryDisplayData(entry);
+            if (!displayData) return null;
+
+            const { activity, user, userPlansProgress } = displayData;
+            const hasImageExpired =
+              entry.imageExpiresAt && new Date(entry.imageExpiresAt) < new Date();
+            const hasImage = entry.imageUrl && !hasImageExpired;
+            const isCollapsed = collapsedEntries.has(entry.id);
+
+            return (
+              <React.Fragment key={`activity-${entry.id}`}>
+                {shouldShowDivider && <AllCaughtUpDivider ref={dividerRef} />}
+                <div
+                  ref={(el) => {
+                    if (el) {
+                      entryRefs.current.set(entry.id, el);
+                    } else {
+                      entryRefs.current.delete(entry.id);
+                    }
+                  }}
+                  className={`transition-all duration-500 ${
+                    highlightedEntryId === entry.id
+                      ? cn("ring-4 ring-opacity-50 rounded-2xl", variants.ring)
+                      : ""
+                  } ${
+                    hasImage
+                      ? "col-span-2 sm:col-span-4"
+                      : isCollapsed
+                      ? "col-span-1"
+                      : "col-span-2 sm:col-span-4"
+                  }`}
+                >
+                  <ActivityEntryPhotoCard
+                    key={entry.id}
+                    activity={activity}
+                    activityEntry={entry as any}
+                    user={
+                      user as {
+                        username: string;
+                        name: string;
+                        picture: string;
+                        planType: PlanType;
+                      }
+                    }
+                    userPlansProgressData={userPlansProgress}
+                    isCollapsed={isCollapsed}
+                    onToggleCollapse={() => toggleEntryCollapse(entry.id)}
+                    onAvatarClick={() => {
+                      navigate({
+                        to: `/profile/$username`,
+                        params: { username: user?.username || "" },
+                      });
+                    }}
+                    onUsernameClick={() => {
+                      navigate({
+                        to: `/profile/$username`,
+                        params: { username: user?.username || "" },
+                      });
+                    }}
+                  />
+                </div>
+              </React.Fragment>
+            );
           });
         })()}
     </div>

--- a/apps/frontend-vite/src/contexts/timeline/service.ts
+++ b/apps/frontend-vite/src/contexts/timeline/service.ts
@@ -36,6 +36,34 @@ export type TimelineActivityEntry = Prisma.ActivityEntryGetPayload<{
         };
       };
     };
+    sharedActivityEntry: {
+      include: {
+        sharedActivity: {
+          include: {
+            entries: {
+              include: {
+                user: {
+                  select: {
+                    id: true;
+                    username: true;
+                    name: true;
+                    picture: true;
+                  };
+                };
+                activityEntry: {
+                  select: {
+                    id: true;
+                    userId: true;
+                    deletedAt: true;
+                    activityId: true;
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
   };
 }>;
 

--- a/apps/frontend-vite/src/utils/sharedActivityGrouping.ts
+++ b/apps/frontend-vite/src/utils/sharedActivityGrouping.ts
@@ -1,0 +1,99 @@
+export type FeedActivityItem<TActivity> = {
+  type: "activity";
+  data: TActivity;
+};
+
+export type FeedAchievementItem<TAchievement> = {
+  type: "achievement";
+  data: TAchievement;
+};
+
+export type FeedSharedActivityItem<TActivity> = {
+  type: "sharedActivity";
+  sharedActivityId: string;
+  entries: TActivity[];
+};
+
+type LinkableActivityEntry = {
+  id: string;
+  sharedActivityEntry?: {
+    sharedActivityId?: string | null;
+    sharedActivity?: { id?: string | null } | null;
+  } | null;
+};
+
+export type GroupedFeedItem<TActivity, TAchievement> =
+  | FeedActivityItem<TActivity>
+  | FeedAchievementItem<TAchievement>
+  | FeedSharedActivityItem<TActivity>;
+
+function getSharedActivityId(entry: LinkableActivityEntry): string | null {
+  return (
+    entry.sharedActivityEntry?.sharedActivityId ||
+    entry.sharedActivityEntry?.sharedActivity?.id ||
+    null
+  );
+}
+
+export function groupSharedActivityItems<
+  TActivity extends LinkableActivityEntry,
+  TAchievement,
+>(
+  items: Array<FeedActivityItem<TActivity> | FeedAchievementItem<TAchievement>>
+): Array<GroupedFeedItem<TActivity, TAchievement>> {
+  const visibleSharedEntries = new Map<string, TActivity[]>();
+
+  for (const item of items) {
+    if (item.type !== "activity") continue;
+
+    const sharedActivityId = getSharedActivityId(item.data);
+    if (!sharedActivityId) continue;
+
+    const existing = visibleSharedEntries.get(sharedActivityId) || [];
+    existing.push(item.data);
+    visibleSharedEntries.set(sharedActivityId, existing);
+  }
+
+  const emittedSharedActivities = new Set<string>();
+
+  const groupedItems: Array<GroupedFeedItem<TActivity, TAchievement>> = [];
+
+  for (const item of items) {
+    if (item.type !== "activity") {
+      groupedItems.push(item);
+      continue;
+    }
+
+    const sharedActivityId = getSharedActivityId(item.data);
+    if (!sharedActivityId) {
+      groupedItems.push(item);
+      continue;
+    }
+
+    const entries = visibleSharedEntries.get(sharedActivityId) || [];
+    if (entries.length < 2) {
+      groupedItems.push(item);
+      continue;
+    }
+
+    if (emittedSharedActivities.has(sharedActivityId)) continue;
+
+    emittedSharedActivities.add(sharedActivityId);
+    groupedItems.push({ type: "sharedActivity", sharedActivityId, entries });
+  }
+
+  return groupedItems;
+}
+
+export function getGroupedFeedItemDate<
+  TActivity extends { datetime: Date | string },
+  TAchievement extends { createdAt: Date | string },
+>(item: GroupedFeedItem<TActivity, TAchievement>): Date {
+  if (item.type === "activity") return new Date(item.data.datetime);
+  if (item.type === "achievement") return new Date(item.data.createdAt);
+
+  return item.entries.reduce((newest, entry) => {
+    const entryDate = new Date(entry.datetime);
+    return entryDate > newest ? entryDate : newest;
+  }, new Date(item.entries[0]?.datetime || 0));
+}


### PR DESCRIPTION
## Summary
- Collapse visible linked friend activity entries into one joint activity card in the timeline
- Add a compact joint activity card with participants, per-user quantities, and optional image preview
- Keep individual original cards accessible in an expandable section for comments/reactions/descriptions
- Include filtered shared-activity metadata in timeline API responses

## Stacked PR
This is stacked on top of PR #8 (`feat/shared-activities`) because it depends on the joint-activity linking data model/API from that PR.

## Behavior
- If two linked entries are both visible in the same timeline window, they render as one `Joint activity` card
- If only one linked entry is visible, the existing normal card still renders with the `with @friend` label from PR #8
- Nested shared participants are filtered to the viewer's visible user/activity scope before being returned by `/users/timeline`

## Verification
- `cd apps/backend-node && pnpm build`
- `cd apps/frontend-vite && pnpm build`
- `git diff --check`
