### PR TITLE
feat: log activities with a friend invite

### DIFF
--- a/apps/backend-node/src/routes/activities.ts
+++ b/apps/backend-node/src/routes/activities.ts
@@ -177,6 +177,65 @@ async function findSharedActivityCandidates(activityEntryId: string, userId: str
     }));
 }
 
+async function createPendingSharedActivityInvite({
+  inviterActivityEntryId,
+  inviterUserId,
+  inviteeUserId,
+  activityTitle,
+  inviterUsername,
+}: {
+  inviterActivityEntryId: string;
+  inviterUserId: string;
+  inviteeUserId: string;
+  activityTitle: string;
+  inviterUsername?: string | null;
+}) {
+  if (inviterUserId === inviteeUserId) {
+    throw new Error("Cannot invite yourself to a shared activity");
+  }
+
+  const connectionIds = await getAcceptedConnectionIds(inviterUserId);
+  if (!connectionIds.includes(inviteeUserId)) {
+    throw new Error("Selected user is not an accepted connection");
+  }
+
+  const invite = await prisma.sharedActivityInvite.upsert({
+    where: {
+      inviterActivityEntryId_inviteeUserId: {
+        inviterActivityEntryId,
+        inviteeUserId,
+      },
+    },
+    update: {
+      status: "PENDING",
+      respondedAt: null,
+    },
+    create: {
+      inviterActivityEntryId,
+      inviterUserId,
+      inviteeUserId,
+    },
+    include: {
+      invitee: { select: { id: true, username: true, name: true, picture: true } },
+    },
+  });
+
+  await notificationService.createAndProcessNotification({
+    userId: inviteeUserId,
+    message: `${inviterUsername ? `@${inviterUsername}` : "A friend"} wants to log ${activityTitle} with you`,
+    type: "INFO",
+    relatedId: invite.id,
+    relatedData: {
+      sharedActivityInviteId: invite.id,
+      inviterActivityEntryId,
+      inviterUserId,
+      activityTitle,
+    },
+  });
+
+  return invite;
+}
+
 async function canLinkActivityEntries(userId: string, ownEntryId: string, candidateEntryId: string) {
   const ownEntry = await prisma.activityEntry.findFirst({
     where: { id: ownEntryId, userId, deletedAt: null, activityId: { not: null } },
@@ -344,6 +403,7 @@ router.post(
         isPublic,
         description,
         timezone,
+        withUserId,
       } = req.body;
       const photos = getUploadedActivityEntryPhotos(req);
 
@@ -358,6 +418,22 @@ router.post(
 
       if (!activity) {
         return res.status(404).json({ error: "Activity not found" });
+      }
+
+      const normalizedWithUserId =
+        typeof withUserId === "string" && withUserId.trim().length > 0
+          ? withUserId.trim()
+          : undefined;
+
+      if (normalizedWithUserId) {
+        if (normalizedWithUserId === req.user!.id) {
+          return res.status(400).json({ error: "Cannot invite yourself to a shared activity" });
+        }
+
+        const connectionIds = await getAcceptedConnectionIds(req.user!.id);
+        if (!connectionIds.includes(normalizedWithUserId)) {
+          return res.status(400).json({ error: "Selected user is not an accepted connection" });
+        }
       }
 
       // Check if entry already exists for this date
@@ -542,8 +618,24 @@ router.post(
         data: { progressCalculatedAt: null },
       });
 
+      let sharedActivityInvite: Awaited<ReturnType<typeof createPendingSharedActivityInvite>> | null = null;
+      if (normalizedWithUserId) {
+        try {
+          sharedActivityInvite = await createPendingSharedActivityInvite({
+            inviterActivityEntryId: entry.id,
+            inviterUserId: req.user!.id,
+            inviteeUserId: normalizedWithUserId,
+            activityTitle: `${activity.emoji} ${activity.title}`,
+            inviterUsername: req.user!.username,
+          });
+        } catch (error) {
+          logger.warn("Could not create shared activity invite:", error);
+          return res.status(400).json({ error: "Could not invite that user to this activity" });
+        }
+      }
+
       const sharedActivityCandidates = await findSharedActivityCandidates(entry.id, req.user!.id);
-      res.json({ ...entry, entry, sharedActivityCandidates });
+      res.json({ ...entry, entry, sharedActivityCandidates, sharedActivityInvite });
     } catch (error) {
       logger.error("Error logging activity:", error);
       res.status(500).json({ error: "Failed to log activity" });

--- a/apps/frontend-vite/src/components/ActivityLoggerPopover.tsx
+++ b/apps/frontend-vite/src/components/ActivityLoggerPopover.tsx
@@ -1,6 +1,7 @@
 import AppleLikePopover from "@/components/AppleLikePopover";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
+import { useCurrentUser } from "@/contexts/users";
 import { type Activity } from "@tsw/prisma";
 import { useState } from "react";
 import { toast } from "react-hot-toast";
@@ -12,7 +13,12 @@ interface ActivityLoggerPopoverProps {
   open: boolean;
   onClose: () => void;
   selectedActivity: Activity;
-  onSubmit: (data: { activityId: string; datetime: Date; quantity: number }) => void;
+  onSubmit: (data: {
+    activityId: string;
+    datetime: Date;
+    quantity: number;
+    withUserId?: string;
+  }) => void;
 }
 
 export function ActivityLoggerPopover({
@@ -30,7 +36,18 @@ export function ActivityLoggerPopover({
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isTimePickerExpanded, setIsTimePickerExpanded] = useState(false);
+  const [selectedWithUserId, setSelectedWithUserId] = useState<string | undefined>();
+  const { currentUser } = useCurrentUser();
   const currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const acceptedFriends = [
+    ...(currentUser?.connectionsFrom || [])
+      .filter((connection) => connection.status === "ACCEPTED")
+      .map((connection) => connection.to),
+    ...(currentUser?.connectionsTo || [])
+      .filter((connection) => connection.status === "ACCEPTED")
+      .map((connection) => connection.from),
+  ].filter((user, index, all) => user && all.findIndex((candidate) => candidate.id === user.id) === index);
 
   // Generate hours and minutes options
   const hours = Array.from({ length: 24 }, (_, i) => i.toString().padStart(2, '0'));
@@ -76,6 +93,7 @@ export function ActivityLoggerPopover({
         activityId: selectedActivity.id,
         datetime,
         quantity,
+        withUserId: selectedWithUserId,
       });
     } finally {
       setIsSubmitting(false);
@@ -204,6 +222,46 @@ export function ActivityLoggerPopover({
               </Button>
             ))}
           </div>
+        </div>
+
+        <div>
+          <h3 className="text-lg font-semibold mb-4 text-center">
+            who did this with you?
+          </h3>
+          {acceptedFriends.length > 0 ? (
+            <div className="flex gap-2 overflow-x-auto pb-1">
+              <Button
+                type="button"
+                variant={!selectedWithUserId ? "default" : "secondary"}
+                size="sm"
+                className="shrink-0 rounded-full"
+                onClick={() => setSelectedWithUserId(undefined)}
+              >
+                Just me
+              </Button>
+              {acceptedFriends.map((friend) => (
+                <Button
+                  key={friend.id}
+                  type="button"
+                  variant={selectedWithUserId === friend.id ? "default" : "secondary"}
+                  size="sm"
+                  className="shrink-0 rounded-full"
+                  onClick={() => setSelectedWithUserId(friend.id)}
+                >
+                  {friend.name || `@${friend.username}`}
+                </Button>
+              ))}
+            </div>
+          ) : (
+            <p className="text-center text-sm text-muted-foreground">
+              Add friends to invite someone while logging.
+            </p>
+          )}
+          {selectedWithUserId && (
+            <p className="mt-2 text-center text-xs text-muted-foreground">
+              They’ll get an invite and can accept it when they log their activity.
+            </p>
+          )}
         </div>
 
         <Button

--- a/apps/frontend-vite/src/components/ActivityPhotoUploader.tsx
+++ b/apps/frontend-vite/src/components/ActivityPhotoUploader.tsx
@@ -17,6 +17,7 @@ interface ActivityPhotoUploaderProps {
     activityId: string;
     datetime: Date;
     quantity: number;
+    withUserId?: string;
   };
   onClose: () => void;
   onSuccess: (entryId: string, candidates: SharedActivityCandidate[]) => void;
@@ -43,6 +44,7 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
         quantity: activityData.quantity,
         description,
         photos: selectedFiles,
+        withUserId: activityData.withUserId,
       });
 
       if (!response.entry?.id) {

--- a/apps/frontend-vite/src/contexts/activities/provider.tsx
+++ b/apps/frontend-vite/src/contexts/activities/provider.tsx
@@ -67,6 +67,9 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
         "timezone",
         Intl.DateTimeFormat().resolvedOptions().timeZone
       );
+      if (data.withUserId) {
+        formData.append("withUserId", data.withUserId);
+      }
 
       const photos = data.photos || (data.photo ? [data.photo] : []);
       for (const photo of photos) {

--- a/apps/frontend-vite/src/contexts/activities/types.ts
+++ b/apps/frontend-vite/src/contexts/activities/types.ts
@@ -32,6 +32,7 @@ export interface ActivityLogData {
   description?: string;
   photo?: File;
   photos?: File[];
+  withUserId?: string;
 }
 
 export interface ActivitiesContextType {

--- a/apps/frontend-vite/src/routes/add.tsx
+++ b/apps/frontend-vite/src/routes/add.tsx
@@ -236,6 +236,7 @@ function LogPage() {
                 activityId: selectedActivity!.id,
                 datetime: currentActivityLogData.datetime,
                 quantity: currentActivityLogData.quantity,
+                withUserId: currentActivityLogData.withUserId,
               }}
               onClose={() => {
                 setShowPhotoUploader(false);

--- a/packages/prisma/migrations/20260508120700_add_shared_activity_invites/migration.sql
+++ b/packages/prisma/migrations/20260508120700_add_shared_activity_invites/migration.sql
@@ -1,0 +1,21 @@
+CREATE TYPE "public"."SharedActivityInviteStatus" AS ENUM ('PENDING', 'ACCEPTED', 'REJECTED');
+
+CREATE TABLE "public"."shared_activity_invites" (
+    "id" TEXT NOT NULL,
+    "inviterActivityEntryId" TEXT NOT NULL,
+    "inviterUserId" TEXT NOT NULL,
+    "inviteeUserId" TEXT NOT NULL,
+    "status" "public"."SharedActivityInviteStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "respondedAt" TIMESTAMP(3),
+
+    CONSTRAINT "shared_activity_invites_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "shared_activity_invites_inviterActivityEntryId_inviteeUserId_key" ON "public"."shared_activity_invites"("inviterActivityEntryId", "inviteeUserId");
+CREATE INDEX "shared_activity_invites_inviteeUserId_status_idx" ON "public"."shared_activity_invites"("inviteeUserId", "status");
+CREATE INDEX "shared_activity_invites_inviterUserId_idx" ON "public"."shared_activity_invites"("inviterUserId");
+
+ALTER TABLE "public"."shared_activity_invites" ADD CONSTRAINT "shared_activity_invites_inviterActivityEntryId_fkey" FOREIGN KEY ("inviterActivityEntryId") REFERENCES "public"."activity_entries"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."shared_activity_invites" ADD CONSTRAINT "shared_activity_invites_inviterUserId_fkey" FOREIGN KEY ("inviterUserId") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."shared_activity_invites" ADD CONSTRAINT "shared_activity_invites_inviteeUserId_fkey" FOREIGN KEY ("inviteeUserId") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -94,8 +94,10 @@ model User {
 
   // Achievement posts
   achievementPosts AchievementPost[]
-  sharedActivitiesCreated SharedActivity[]      @relation("SharedActivityCreatedBy")
-  sharedActivityEntries   SharedActivityEntry[]
+  sharedActivitiesCreated     SharedActivity[]       @relation("SharedActivityCreatedBy")
+  sharedActivityEntries       SharedActivityEntry[]
+  sharedActivityInvitesSent   SharedActivityInvite[]  @relation("SharedActivityInviteInviter")
+  sharedActivityInvitesReceived SharedActivityInvite[] @relation("SharedActivityInviteInvitee")
 
   // Level celebration tracking
   celebratedLevelThreshold Int?
@@ -179,6 +181,7 @@ model ActivityEntry {
   reactions Reaction[]
   comments  Comment[]
   sharedActivityEntry SharedActivityEntry?
+  sharedActivityInvitesInitiated SharedActivityInvite[]
 
   @@index([userId, deletedAt])
   @@index([userId, datetime, deletedAt])
@@ -303,6 +306,26 @@ model SharedActivityEntry {
   @@index([sharedActivityId])
   @@index([userId])
   @@map("shared_activity_entries")
+  @@schema("public")
+}
+
+model SharedActivityInvite {
+  id                     String                     @id @default(cuid())
+  inviterActivityEntryId String
+  inviterUserId          String
+  inviteeUserId          String
+  status                 SharedActivityInviteStatus @default(PENDING)
+  createdAt              DateTime                   @default(now())
+  respondedAt            DateTime?
+
+  inviterActivityEntry ActivityEntry @relation(fields: [inviterActivityEntryId], references: [id], onDelete: Cascade)
+  inviter              User          @relation("SharedActivityInviteInviter", fields: [inviterUserId], references: [id], onDelete: Cascade)
+  invitee              User          @relation("SharedActivityInviteInvitee", fields: [inviteeUserId], references: [id], onDelete: Cascade)
+
+  @@unique([inviterActivityEntryId, inviteeUserId])
+  @@index([inviteeUserId, status])
+  @@index([inviterUserId])
+  @@map("shared_activity_invites")
   @@schema("public")
 }
 
@@ -791,6 +814,14 @@ enum NotificationStatus {
   PROCESSED
   OPENED
   CONCLUDED
+
+  @@schema("public")
+}
+
+enum SharedActivityInviteStatus {
+  PENDING
+  ACCEPTED
+  REJECTED
 
   @@schema("public")
 }


### PR DESCRIPTION
## Summary
- Add a companion selector to the activity logging popover so users can choose an accepted friend while logging.
- Forward `withUserId` through the photo/proof step and activity log API request.
- Add pending shared activity invite persistence plus notification creation when logging with a friend.

## Validation
- `PATH=/home/alex/.local/node22/bin:$PATH pnpm --filter @tsw/prisma db:generate`
- `PATH=/home/alex/.local/node22/bin:$PATH pnpm --filter backend-node build`
- `PATH=/home/alex/.local/node22/bin:$PATH pnpm --filter frontend-vite build`
- Mobile Playwright QA at 390x844 with mocked signed-in data; verified the selected friend is sent as `withUserId=user-friend-1` in the log request form data.

## Screenshot evidence

| Scenario | Evidence |
|---|---|
| Mobile log activity popover with `who did this with you?` section and Maria selected | ![Mobile log with someone selected](https://raw.githubusercontent.com/alramalho/self-tracking-software/qa/log-with-someone-evidence-t1c838b60/qa-evidence/log-with-someone/mobile-log-with-someone-selected.png) |
| Mobile proof step reached after selecting a friend | ![Mobile proof step](https://raw.githubusercontent.com/alramalho/self-tracking-software/qa/log-with-someone-evidence-t1c838b60/qa-evidence/log-with-someone/mobile-log-with-someone-photo-step.png) |
| Mobile flow after logging without photo | ![Mobile flow after submit](https://raw.githubusercontent.com/alramalho/self-tracking-software/qa/log-with-someone-evidence-t1c838b60/qa-evidence/log-with-someone/mobile-log-with-someone-flow.png) |

Notes:
- `apps/frontend-vite/src/routeTree.gen.ts` was regenerated by `tsr generate`, but its diff only added the pre-existing `/reset-password` route, so I reverted it as unrelated generated-file noise.
- Do not merge without Alex approval.
