### PR TITLE
Optimize timeline pagination

### DIFF
--- a/apps/backend-node/src/routes/achievements.ts
+++ b/apps/backend-node/src/routes/achievements.ts
@@ -502,6 +502,36 @@ router.post(
   }
 );
 
+// Get comments for achievement post
+router.get(
+  "/:achievementPostId/comments",
+  requireAuth,
+  async (
+    req: AuthenticatedRequest,
+    res: Response
+  ): Promise<Response | void> => {
+    try {
+      const { achievementPostId } = req.params;
+
+      const comments = await prisma.comment.findMany({
+        where: {
+          achievementPostId,
+          deletedAt: null,
+        },
+        include: {
+          user: { select: { username: true, picture: true, name: true } },
+        },
+        orderBy: { createdAt: "asc" },
+      });
+
+      res.json({ comments });
+    } catch (error) {
+      logger.error("Error getting achievement comments:", error);
+      res.status(500).json({ error: "Failed to get comments" });
+    }
+  }
+);
+
 // Add comment to achievement post
 router.post(
   "/:achievementPostId/comments",

--- a/apps/backend-node/src/routes/activities.ts
+++ b/apps/backend-node/src/routes/activities.ts
@@ -1442,6 +1442,36 @@ router.delete(
   }
 );
 
+// Get comments for activity entry
+router.get(
+  "/activity-entries/:activityEntryId/comments",
+  requireAuth,
+  async (
+    req: AuthenticatedRequest,
+    res: Response
+  ): Promise<Response | void> => {
+    try {
+      const { activityEntryId } = req.params;
+
+      const comments = await prisma.comment.findMany({
+        where: {
+          activityEntryId,
+          deletedAt: null,
+        },
+        include: {
+          user: { select: { username: true, picture: true, name: true } },
+        },
+        orderBy: { createdAt: "asc" },
+      });
+
+      res.json({ comments });
+    } catch (error) {
+      logger.error("Error getting comments:", error);
+      res.status(500).json({ error: "Failed to get comments" });
+    }
+  }
+);
+
 // Add comment to activity entry
 router.post(
   "/activity-entries/:activityEntryId/comments",

--- a/apps/backend-node/src/routes/users.ts
+++ b/apps/backend-node/src/routes/users.ts
@@ -80,6 +80,42 @@ const basicUserInclude = {
   },
 } as const;
 
+const DEFAULT_TIMELINE_LIMIT = 20;
+const MAX_TIMELINE_LIMIT = 30;
+
+type TimelineCursor = {
+  ts: string;
+  id: string;
+};
+
+const encodeTimelineCursor = (cursor: TimelineCursor) =>
+  Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+
+const decodeTimelineCursor = (value: unknown): TimelineCursor | null => {
+  if (!value || typeof value !== "string") return null;
+
+  try {
+    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    if (
+      typeof parsed?.ts === "string" &&
+      typeof parsed?.id === "string" &&
+      !Number.isNaN(new Date(parsed.ts).getTime())
+    ) {
+      return { ts: parsed.ts, id: parsed.id };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+};
+
+const getTimelineLimit = (value: unknown) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TIMELINE_LIMIT;
+  return Math.min(Math.floor(parsed), MAX_TIMELINE_LIMIT);
+};
+
 // Health check
 usersRouter.get("/user-health", (_req: Request, res: Response) => {
   res.json({ status: "ok" });
@@ -756,6 +792,7 @@ usersRouter.get(
           recommendedActivities: [],
           recommendedUsers: [],
           achievementPosts: [],
+          nextCursor: null,
         });
         return;
       }
@@ -775,10 +812,14 @@ usersRouter.get(
           recommendedActivities: [],
           recommendedUsers: [],
           achievementPosts: [],
+          nextCursor: null,
         });
         return;
       }
 
+      const limit = getTimelineLimit(req.query.limit);
+      const cursor = decodeTimelineCursor(req.query.cursor);
+      const cursorDate = cursor ? new Date(cursor.ts) : null;
       const userIds = [user.id, ...connections.map((friend) => friend.id)];
       const allUsers = [user, ...connections];
 
@@ -824,41 +865,6 @@ usersRouter.get(
         })
         .map((a) => a.id);
 
-      // Fetch only activity entries for valid activities
-      const filteredActivityEntries = await prisma.activityEntry.findMany({
-        where: {
-          userId: { in: userIds },
-          activityId: { in: validActivityIds },
-          deletedAt: null,
-        },
-        orderBy: [{ datetime: "desc" }, { createdAt: "desc" }],
-        take: 50,
-        include: {
-          activity: true,
-          comments: {
-            where: { deletedAt: null },
-            orderBy: { createdAt: "asc" },
-            include: {
-              user: {
-                select: { id: true, username: true, picture: true },
-              },
-            },
-          },
-          reactions: {
-            include: {
-              user: {
-                select: {
-                  id: true,
-                  username: true,
-                  picture: true,
-                  planType: true,
-                },
-              },
-            },
-          },
-        },
-      });
-
       // Get public plan IDs for connected users
       const publicPlanIds = allUsers.flatMap(
         (u) =>
@@ -866,61 +872,190 @@ usersRouter.get(
           []
       );
 
-      // Fetch achievement posts for users with PUBLIC plans OR level-up posts (no plan)
-      const achievementPosts = await prisma.achievementPost.findMany({
-        where: {
-          userId: { in: userIds },
-          deletedAt: null,
-          OR: [
-            { planId: { in: publicPlanIds } },
-            { planId: null, achievementType: "LEVEL_UP" },
-          ],
-        },
-        orderBy: { createdAt: "desc" },
-        take: 50,
-        include: {
-          user: {
-            select: {
-              id: true,
-              username: true,
-              name: true,
-              picture: true,
-            },
+      const activityCursorWhere =
+        cursor && cursorDate
+          ? {
+              OR: [
+                { datetime: { lt: cursorDate } },
+                { datetime: cursorDate, id: { lt: cursor.id } },
+              ],
+            }
+          : {};
+
+      const achievementCursorWhere =
+        cursor && cursorDate
+          ? {
+              OR: [
+                { createdAt: { lt: cursorDate } },
+                { createdAt: cursorDate, id: { lt: cursor.id } },
+              ],
+            }
+          : {};
+
+      const [activityCandidates, achievementCandidates] = await Promise.all([
+        prisma.activityEntry.findMany({
+          where: {
+            userId: { in: userIds },
+            activityId: { in: validActivityIds },
+            deletedAt: null,
+            ...activityCursorWhere,
           },
-          plan: {
-            select: {
-              id: true,
-              goal: true,
-              emoji: true,
-              backgroundImageUrl: true,
-            },
-          },
-          images: {
-            orderBy: { sortOrder: "asc" },
-          },
-          comments: {
-            where: { deletedAt: null },
-            orderBy: { createdAt: "asc" },
-            include: {
-              user: {
-                select: { id: true, username: true, picture: true },
+          orderBy: [{ datetime: "desc" }, { id: "desc" }],
+          take: limit + 1,
+          include: {
+            comments: {
+              where: { deletedAt: null },
+              orderBy: { createdAt: "desc" },
+              take: 2,
+              include: {
+                user: {
+                  select: { id: true, username: true, picture: true },
+                },
               },
             },
-          },
-          reactions: {
-            include: {
-              user: {
-                select: {
-                  id: true,
-                  username: true,
-                  picture: true,
-                  planType: true,
+            reactions: {
+              include: {
+                user: {
+                  select: {
+                    id: true,
+                    username: true,
+                  },
+                },
+              },
+            },
+            _count: {
+              select: {
+                comments: true,
+              },
+            },
+            sharedActivityEntry: {
+              include: {
+                sharedActivity: {
+                  include: {
+                    entries: {
+                      include: {
+                        user: {
+                          select: {
+                            id: true,
+                            username: true,
+                            name: true,
+                            picture: true,
+                          },
+                        },
+                        activityEntry: {
+                          select: { id: true, userId: true, deletedAt: true },
+                        },
+                      },
+                    },
+                  },
                 },
               },
             },
           },
-        },
+        }),
+        prisma.achievementPost.findMany({
+          where: {
+            userId: { in: userIds },
+            deletedAt: null,
+            OR: [
+              { planId: { in: publicPlanIds } },
+              { planId: null, achievementType: "LEVEL_UP" },
+            ],
+            ...(cursor ? { AND: [achievementCursorWhere] } : {}),
+          },
+          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+          take: limit + 1,
+          include: {
+            user: {
+              select: {
+                id: true,
+                username: true,
+                name: true,
+                picture: true,
+              },
+            },
+            plan: {
+              select: {
+                id: true,
+                goal: true,
+                emoji: true,
+                backgroundImageUrl: true,
+              },
+            },
+            images: {
+              orderBy: { sortOrder: "asc" },
+            },
+            comments: {
+              where: { deletedAt: null },
+              orderBy: { createdAt: "desc" },
+              take: 2,
+              include: {
+                user: {
+                  select: { id: true, username: true, picture: true },
+                },
+              },
+            },
+            reactions: {
+              include: {
+                user: {
+                  select: {
+                    id: true,
+                    username: true,
+                  },
+                },
+              },
+            },
+            _count: {
+              select: {
+                comments: true,
+              },
+            },
+          },
+        }),
+      ]);
+
+      const mergedTimelineItems = [
+        ...activityCandidates.map((entry) => ({
+          type: "activity" as const,
+          id: entry.id,
+          timestamp: entry.datetime,
+          data: {
+            ...entry,
+            comments: [...entry.comments].reverse(),
+          },
+        })),
+        ...achievementCandidates.map((post) => ({
+          type: "achievement" as const,
+          id: post.id,
+          timestamp: post.createdAt,
+          data: {
+            ...post,
+            comments: [...post.comments].reverse(),
+          },
+        })),
+      ].sort((a, b) => {
+        const timeDiff = b.timestamp.getTime() - a.timestamp.getTime();
+        if (timeDiff !== 0) return timeDiff;
+        return b.id.localeCompare(a.id);
       });
+
+      const pageItems = mergedTimelineItems.slice(0, limit);
+      const hasMoreItems = mergedTimelineItems.length > limit;
+      const lastPageItem = pageItems[pageItems.length - 1];
+      const nextCursor = hasMoreItems && lastPageItem
+        ? encodeTimelineCursor({
+            ts: lastPageItem.timestamp.toISOString(),
+            id: lastPageItem.id,
+          })
+        : null;
+
+      const filteredActivityEntries = pageItems
+        .filter((item) => item.type === "activity")
+        .map((item) => item.data);
+
+      const achievementPosts = pageItems
+        .filter((item) => item.type === "achievement")
+        .map((item) => item.data);
 
       const activityIds = Array.from(
         new Set(
@@ -933,14 +1068,21 @@ usersRouter.get(
         where: { id: { in: activityIds } },
       });
 
-      // Collect all plan IDs from all users
-      const allPlanIds = allUsers.flatMap(
-        (u) => u.plans?.map((p) => p.id) || []
+      const pageActivityIdSet = new Set(activityIds);
+      const pagePlanIds = allUsers.flatMap(
+        (u) =>
+          u.plans
+            ?.filter((plan) =>
+              plan.activities?.some((activity) =>
+                pageActivityIdSet.has(activity.id)
+              )
+            )
+            .map((p) => p.id) || []
       );
 
       // Batch load progress for all plans
       const plansProgress = await plansService.getBatchPlanProgress(
-        allPlanIds,
+        pagePlanIds,
         req.user!.id,
         false // Use cache
       );
@@ -951,10 +1093,14 @@ usersRouter.get(
       // Augment each user's plans with progress data
       const usersWithProgress = allUsers.map((u) => ({
         ...u,
-        plans: u.plans?.map((plan) => ({
-          ...plan,
-          progress: progressMap.get(plan.id),
-        })),
+        plans: u.plans
+          ?.filter((plan) =>
+            plan.activities?.some((activity) => pageActivityIdSet.has(activity.id))
+          )
+          .map((plan) => ({
+            ...plan,
+            progress: progressMap.get(plan.id),
+          })),
       }));
 
       res.json({
@@ -962,6 +1108,7 @@ usersRouter.get(
         recommendedActivities: activities,
         recommendedUsers: usersWithProgress,
         achievementPosts: achievementPosts,
+        nextCursor,
       });
     } catch (error) {
       logger.error("Failed to fetch timeline data:", error);

--- a/apps/frontend-vite/src/components/AchievementPostCard.tsx
+++ b/apps/frontend-vite/src/components/AchievementPostCard.tsx
@@ -15,6 +15,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { Trash2, Pencil, Target, Sprout, Rocket } from "lucide-react";
 import { type TimelineAchievementPost } from "@/contexts/timeline/service";
+import { useApiWithAuth } from "@/api";
 import { type Comment } from "@tsw/prisma";
 import CommentSection from "./CommentSection";
 import { ProgressRing } from "./ProgressRing";
@@ -107,6 +108,7 @@ const AchievementPostCard: React.FC<AchievementPostCardProps> = ({
   const [replyToUsername, setReplyToUsername] = useState<string | undefined>();
   const [showMedalExplainer, setShowMedalExplainer] = useState(false);
   const [showEditDialog, setShowEditDialog] = useState(false);
+  const api = useApiWithAuth();
 
   useEffect(() => {
     setReactions(
@@ -162,9 +164,26 @@ const AchievementPostCard: React.FC<AchievementPostCardProps> = ({
   } = useActivities();
 
 
-  const comments = (achievementPost.comments || []) as (Comment & {
+  const [comments, setComments] = useState((achievementPost.comments || []) as (Comment & {
     user: { username: string; picture: string };
-  })[];
+  })[]);
+  const commentsCount =
+    (achievementPost as typeof achievementPost & {
+      _count?: { comments?: number };
+    })._count?.comments ?? comments.length;
+  const hasMoreComments = commentsCount > comments.length;
+
+  useEffect(() => {
+    setComments((achievementPost.comments || []) as (Comment & {
+      user: { username: string; picture: string };
+    })[]);
+  }, [achievementPost.comments]);
+
+  const loadAllComments = useCallback(async () => {
+    if (!hasMoreComments) return;
+    const response = await api.get(`/achievements/${achievementPost.id}/comments`);
+    setComments(response.data.comments || []);
+  }, [achievementPost.id, api, hasMoreComments]);
 
   // JSConfetti instance
   const jsConfettiRef = useRef<JSConfetti | null>(null);
@@ -567,6 +586,8 @@ const AchievementPostCard: React.FC<AchievementPostCardProps> = ({
             hasImage={true}
             showAllComments={showAllComments}
             onToggleShowAll={setShowAllComments}
+            hasMoreComments={hasMoreComments}
+            onLoadAllComments={loadAllComments}
             isAddingComment={false}
             isRemovingComment={isRemovingComment}
             className="[&>div:last-child]:hidden" // Hide the input section, only show comments

--- a/apps/frontend-vite/src/components/ActivityEntryPhotoCard.tsx
+++ b/apps/frontend-vite/src/components/ActivityEntryPhotoCard.tsx
@@ -1,4 +1,5 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useApiWithAuth } from "@/api";
 import { useActivities } from "@/contexts/activities/useActivities";
 import { type PlanProgressData } from "@/contexts/plans-progress";
 import { useTheme } from "@/contexts/theme/useTheme";
@@ -110,6 +111,7 @@ const ActivityEntryPhotoCard: React.FC<ActivityEntryPhotoCardProps> = ({
 }) => {
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const [reactions, setReactions] = useState<ReactionCount>({});
+  const api = useApiWithAuth();
 
   useEffect(() => {
     setReactions(
@@ -157,7 +159,23 @@ const ActivityEntryPhotoCard: React.FC<ActivityEntryPhotoCardProps> = ({
     isAddingComment,
     isRemovingComment,
   } = useActivities();
-  const comments = activityEntry.comments || [];
+  const [comments, setComments] = useState(activityEntry.comments || []);
+  const commentsCount =
+    (activityEntry as typeof activityEntry & { _count?: { comments?: number } })
+      ._count?.comments ?? comments.length;
+  const hasMoreComments = commentsCount > comments.length;
+
+  useEffect(() => {
+    setComments(activityEntry.comments || []);
+  }, [activityEntry.comments]);
+
+  const loadAllComments = useCallback(async () => {
+    if (!hasMoreComments) return;
+    const response = await api.get(
+      `/activities/activity-entries/${activityEntry.id}/comments`
+    );
+    setComments(response.data.comments || []);
+  }, [activityEntry.id, api, hasMoreComments]);
 
   useEffect(() => {
     if (textRef.current) {
@@ -579,6 +597,8 @@ const ActivityEntryPhotoCard: React.FC<ActivityEntryPhotoCardProps> = ({
                 hasImage={true}
                 showAllComments={showAllComments}
                 onToggleShowAll={setShowAllComments}
+                hasMoreComments={hasMoreComments}
+                onLoadAllComments={loadAllComments}
                 isAddingComment={isAddingComment}
                 isRemovingComment={isRemovingComment}
               />
@@ -706,6 +726,8 @@ const ActivityEntryPhotoCard: React.FC<ActivityEntryPhotoCardProps> = ({
                 fullWidth={true}
                 showAllComments={showAllComments}
                 onToggleShowAll={setShowAllComments}
+                hasMoreComments={hasMoreComments}
+                onLoadAllComments={loadAllComments}
                 isAddingComment={isAddingComment}
                 isRemovingComment={isRemovingComment}
               />

--- a/apps/frontend-vite/src/components/CommentSection.tsx
+++ b/apps/frontend-vite/src/components/CommentSection.tsx
@@ -20,6 +20,8 @@ interface CommentSectionProps {
   fullWidth?: boolean;
   showAllComments?: boolean;
   onToggleShowAll?: (shown: boolean) => void;
+  hasMoreComments?: boolean;
+  onLoadAllComments?: () => Promise<void>;
   isAddingComment?: boolean;
   isRemovingComment?: boolean;
   className?: string;
@@ -66,6 +68,8 @@ export const CommentSection: React.FC<CommentSectionProps> = ({
   fullWidth = false,
   showAllComments: externalShowAllState,
   onToggleShowAll,
+  hasMoreComments = false,
+  onLoadAllComments,
   isAddingComment = false,
   isRemovingComment = false,
   className = "",
@@ -253,8 +257,11 @@ export const CommentSection: React.FC<CommentSectionProps> = ({
     }
   };
 
-  const handleToggleShowAll = () => {
+  const handleToggleShowAll = async () => {
     const newState = !showAllComments;
+    if (newState && hasMoreComments && onLoadAllComments) {
+      await onLoadAllComments();
+    }
     setShowAllComments(newState);
     if (onToggleShowAll) onToggleShowAll(newState);
   };
@@ -272,7 +279,7 @@ export const CommentSection: React.FC<CommentSectionProps> = ({
 
   const commentBg = hasImage ? variants.card.glassBg : "dark:bg-muted/30 bg-gray-200/30";
   const visibleComments = getVisibleComments();
-  const hasHiddenComments = comments.length > 2 && !showAllComments;
+  const hasHiddenComments = (comments.length > 2 || hasMoreComments) && !showAllComments;
 
   if (comments.length === 0 && !currentUser) {
     return null;
@@ -288,7 +295,9 @@ export const CommentSection: React.FC<CommentSectionProps> = ({
               onClick={handleToggleShowAll}
               className={`w-full text-center py-2 ${commentBg} rounded-lg text-sm text-muted-foreground flex items-center justify-center gap-1 border border-white/20 dark:border-gray-700/20 shadow-sm backdrop-blur-lg`}
             >
-              Show all {comments.length} comments{" "}
+              {comments.length > 2
+                ? `Show all ${comments.length} comments`
+                : "Show all comments"}{" "}
               <ChevronDown className="h-4 w-4" />
             </button>
           )}

--- a/apps/frontend-vite/src/components/TimelineRenderer.tsx
+++ b/apps/frontend-vite/src/components/TimelineRenderer.tsx
@@ -48,7 +48,13 @@ const TimelineRenderer: React.FC<{
   onOpenSearch: () => void;
   highlightActivityEntryId?: string;
 }> = ({ onOpenSearch, highlightActivityEntryId }) => {
-  const { timelineData, isLoadingTimeline } = useTimeline();
+  const {
+    timelineData,
+    isLoadingTimeline,
+    isFetchingNextTimelinePage,
+    hasMoreTimeline,
+    fetchNextTimelinePage,
+  } = useTimeline();
   const { currentUser } = useCurrentUser();
   const { plans } = usePlans();
   const navigate = useNavigate();
@@ -95,6 +101,7 @@ const TimelineRenderer: React.FC<{
     new Set()
   );
   const dividerRef = useRef<HTMLDivElement>(null);
+  const loadMoreRef = useRef<HTMLDivElement>(null);
   const [dividerSeen, setDividerSeen] = useState(false);
 
   // Track when user last viewed timeline (localStorage for immediate UI, synced with DB)
@@ -206,7 +213,6 @@ const TimelineRenderer: React.FC<{
       items.push({ type: "activity", data: entry });
     });
 
-    console.log("timelineData.achievementPosts", timelineData.achievementPosts);
     // Add achievement posts
     (timelineData.achievementPosts || []).forEach((post) => {
       items.push({ type: "achievement", data: post });
@@ -227,6 +233,59 @@ const TimelineRenderer: React.FC<{
 
     return items;
   }, [timelineData]);
+
+  const activityById = useMemo(() => {
+    const map = new Map<string, Activity>();
+    [...(timelineData?.recommendedActivities || []), ...activities].forEach(
+      (activity) => {
+        map.set(activity.id, activity);
+      }
+    );
+    return map;
+  }, [activities, timelineData?.recommendedActivities]);
+
+  const userById = useMemo(() => {
+    const map = new Map<string, any>();
+    [...(timelineData?.recommendedUsers || []), currentUser]
+      .filter(Boolean)
+      .forEach((user: any) => {
+        map.set(user.id, user);
+      });
+    return map;
+  }, [currentUser, timelineData?.recommendedUsers]);
+
+  const planProgressByUserAndActivity = useMemo(() => {
+    const map = new Map<string, any[]>();
+
+    (timelineData?.recommendedUsers || []).forEach((user) => {
+      user.plans?.forEach((plan) => {
+        plan.activities?.forEach((activity) => {
+          const key = `${user.id}:${activity.id}`;
+          const existing = map.get(key) || [];
+          map.set(key, [...existing, plan.progress]);
+        });
+      });
+    });
+
+    return map;
+  }, [timelineData?.recommendedUsers]);
+
+  useEffect(() => {
+    if (!loadMoreRef.current || !hasMoreTimeline) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+        if (entry.isIntersecting && !isFetchingNextTimelinePage) {
+          fetchNextTimelinePage();
+        }
+      },
+      { rootMargin: "600px" }
+    );
+
+    observer.observe(loadMoreRef.current);
+    return () => observer.disconnect();
+  }, [fetchNextTimelinePage, hasMoreTimeline, isFetchingNextTimelinePage]);
 
   // Check if there will be a divider shown (new posts exist AND we have a lastViewedTimelineAt)
   const willShowDivider = useMemo(() => {
@@ -544,14 +603,6 @@ const TimelineRenderer: React.FC<{
               return itemDate > lastViewed;
             });
 
-          // count the timeline items types
-          console.log(
-            "timeline items types",
-            mergedTimelineItems.reduce((acc: Record<string, number>, item: TimelineItem) => {
-              acc[item.type] = (acc[item.type] || 0) + 1;
-              return acc;
-            }, {} as Record<string, number>)
-          );
           return mergedTimelineItems.map((item, index) => {
             if (item.type === "achievement") {
               // Render achievement post
@@ -594,31 +645,15 @@ const TimelineRenderer: React.FC<{
             } else {
               // Render activity entry
               const entry = item.data;
-              const allActivities = [
-                ...(timelineData?.recommendedActivities || []),
-                ...activities,
-              ];
-              const activity = allActivities?.find(
-                (a: Activity) => a.id === entry.activityId
-              );
-              const allUsers = [
-                ...(timelineData?.recommendedUsers || []),
-                currentUser,
-              ];
-              const user = allUsers?.find(
-                (u: any) => u.id === activity?.userId
-              );
+              const activity = entry.activityId
+                ? activityById.get(entry.activityId)
+                : undefined;
+              const user = activity ? userById.get(activity.userId) : undefined;
               if (!activity || !user || user.username === null) return null;
 
-              const timelineUser = timelineData?.recommendedUsers?.find(
-                (u) => u.id === user.id
-              );
               const userPlansProgress =
-                timelineUser?.plans
-                  ?.filter((plan) =>
-                    plan.activities?.some((a) => a.id === activity?.id)
-                  )
-                  .map((plan) => plan.progress) || [];
+                planProgressByUserAndActivity.get(`${user.id}:${activity.id}`) ||
+                [];
 
               const hasImageExpired =
                 entry.imageExpiresAt &&
@@ -698,6 +733,12 @@ const TimelineRenderer: React.FC<{
             }
           });
         })()}
+      <div ref={loadMoreRef} className="col-span-2 sm:col-span-4 h-6" />
+      {isFetchingNextTimelinePage && (
+        <div className="col-span-2 sm:col-span-4 flex justify-center py-4">
+          <RefreshCcw className="w-4 h-4 animate-spin text-muted-foreground" />
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/frontend-vite/src/contexts/achievements/provider.tsx
+++ b/apps/frontend-vite/src/contexts/achievements/provider.tsx
@@ -10,6 +10,10 @@ import { useAccountLevel } from "@/hooks/useAccountLevel";
 import { type AchievementsContextType, type CelebrationData, type CreateAchievementPostData, type UpdateAchievementPostData } from "./types";
 import { type TimelineData, type TimelineAchievementPost, normalizeAchievementPost } from "../timeline/service";
 
+type TimelineCache =
+  | TimelineData
+  | { pages: TimelineData[]; pageParams: unknown[] };
+
 export const AchievementsContext = createContext<
   AchievementsContextType | undefined
 >(undefined);
@@ -342,16 +346,28 @@ export const AchievementsProvider: React.FC<{ children: React.ReactNode }> = ({
       const updatedMessage = updatedPost.message;
 
       // Update timeline cache (for own profile - achievementPosts come from timeline)
-      queryClient.setQueryData(["timeline"], (old: TimelineData) => {
+      queryClient.setQueryData(["timeline"], (old: TimelineCache | undefined) => {
         if (!old) return old;
-        const newAchievementPosts = old.achievementPosts?.map((post) =>
-          post.id === input.achievementPostId
-            ? { ...post, message: updatedMessage, images: updatedImages }
-            : post
-        ) || [];
+        const updatePosts = (posts: TimelineData["achievementPosts"]) =>
+          posts.map((post) =>
+            post.id === input.achievementPostId
+              ? { ...post, message: updatedMessage, images: updatedImages }
+              : post
+          );
+
+        if ("pages" in old) {
+          return {
+            ...old,
+            pages: old.pages.map((page) => ({
+              ...page,
+              achievementPosts: updatePosts(page.achievementPosts),
+            })),
+          };
+        }
+
         return {
           ...old,
-          achievementPosts: newAchievementPosts,
+          achievementPosts: updatePosts(old.achievementPosts),
         };
       });
 

--- a/apps/frontend-vite/src/contexts/activities/provider.tsx
+++ b/apps/frontend-vite/src/contexts/activities/provider.tsx
@@ -25,6 +25,54 @@ import {
   type ReturnedActivityEntriesType,
 } from "./types";
 
+type TimelineCache =
+  | TimelineData
+  | { pages: TimelineData[]; pageParams: unknown[] };
+
+const updateTimelineActivityEntries = (
+  old: TimelineCache | undefined,
+  updater: (
+    entries: TimelineData["recommendedActivityEntries"]
+  ) => TimelineData["recommendedActivityEntries"]
+) => {
+  if (!old) return old;
+  if ("pages" in old) {
+    return {
+      ...old,
+      pages: old.pages.map((page) => ({
+        ...page,
+        recommendedActivityEntries: updater(page.recommendedActivityEntries),
+      })),
+    };
+  }
+  return {
+    ...old,
+    recommendedActivityEntries: updater(old.recommendedActivityEntries),
+  };
+};
+
+const updateTimelineAchievementPosts = (
+  old: TimelineCache | undefined,
+  updater: (
+    posts: TimelineData["achievementPosts"]
+  ) => TimelineData["achievementPosts"]
+) => {
+  if (!old) return old;
+  if ("pages" in old) {
+    return {
+      ...old,
+      pages: old.pages.map((page) => ({
+        ...page,
+        achievementPosts: updater(page.achievementPosts),
+      })),
+    };
+  }
+  return {
+    ...old,
+    achievementPosts: updater(old.achievementPosts),
+  };
+};
+
 export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
@@ -227,15 +275,11 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
           return old.filter((entry) => entry.id !== id);
         }
       );
-      queryClient.setQueryData(["timeline"], (old: TimelineData) => {
-        if (!old) return queryClient.refetchQueries({ queryKey: ["timeline"] });
-        return {
-          ...old,
-          recommendedActivityEntries: old.recommendedActivityEntries.filter(
-            (entry) => entry.id !== id
-          ),
-        };
-      });
+      queryClient.setQueryData(["timeline"], (old: TimelineCache | undefined) =>
+        updateTimelineActivityEntries(old, (entries) =>
+          entries.filter((entry) => entry.id !== id)
+        )
+      );
 
       // Refetch plans to update progress after entry deletion
       await queryClient.refetchQueries({ queryKey: ["plans"] });
@@ -275,19 +319,15 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
         }
       );
 
-      queryClient.setQueryData(["timeline"], (old: TimelineData) => {
-        if (!old) return queryClient.refetchQueries({ queryKey: ["timeline"] });
-        return {
-          ...old,
-          recommendedActivityEntries: old.recommendedActivityEntries.map(
-            (entry) => {
-              return entry.id === input.activityEntryId
-                ? { ...entry, reactions: reactions }
-                : entry;
-            }
-          ),
-        };
-      });
+      queryClient.setQueryData(["timeline"], (old: TimelineCache | undefined) =>
+        updateTimelineActivityEntries(old, (entries) =>
+          entries.map((entry) =>
+            entry.id === input.activityEntryId
+              ? { ...entry, reactions: reactions }
+              : entry
+          )
+        )
+      );
       queryClient.setQueryData(
         ["user", input.userUsername],
         (old: HydratedUser) => {
@@ -326,19 +366,15 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
       return response.data.comments;
     },
     onSuccess: (comments, input) => {
-      queryClient.setQueryData(["timeline"], (old: TimelineData) => {
-        if (!old) return queryClient.refetchQueries({ queryKey: ["timeline"] });
-        return {
-          ...old,
-          recommendedActivityEntries: old.recommendedActivityEntries?.map(
-            (entry) => {
-              return entry.id === input.activityEntryId
-                ? { ...entry, comments: comments }
-                : entry;
-            }
-          ),
-        };
-      });
+      queryClient.setQueryData(["timeline"], (old: TimelineCache | undefined) =>
+        updateTimelineActivityEntries(old, (entries) =>
+          entries.map((entry) =>
+            entry.id === input.activityEntryId
+              ? { ...entry, comments: comments }
+              : entry
+          )
+        )
+      );
       queryClient.setQueryData(
         ["user", input.userUsername],
         (old: HydratedUser) => {
@@ -376,19 +412,15 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
       return response.data.comments;
     },
     onSuccess: (comments, input) => {
-      queryClient.setQueryData(["timeline"], (old: TimelineData) => {
-        if (!old) return queryClient.refetchQueries({ queryKey: ["timeline"] });
-        return {
-          ...old,
-          recommendedActivityEntries: old.recommendedActivityEntries.map(
-            (entry) => {
-              return entry.id === input.activityEntryId
-                ? { ...entry, comments: comments }
-                : entry;
-            }
-          ),
-        };
-      });
+      queryClient.setQueryData(["timeline"], (old: TimelineCache | undefined) =>
+        updateTimelineActivityEntries(old, (entries) =>
+          entries.map((entry) =>
+            entry.id === input.activityEntryId
+              ? { ...entry, comments: comments }
+              : entry
+          )
+        )
+      );
       queryClient.setQueryData(
         ["user", input.userUsername],
         (old: HydratedUser) => {
@@ -430,17 +462,15 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
       return response.data.reactions;
     },
     onSuccess: (reactions, input) => {
-      queryClient.setQueryData(["timeline"], (old: TimelineData) => {
-        if (!old) return queryClient.refetchQueries({ queryKey: ["timeline"] });
-        return {
-          ...old,
-          achievementPosts: old.achievementPosts?.map((post) => {
-            return post.id === input.achievementPostId
+      queryClient.setQueryData(["timeline"], (old: TimelineCache | undefined) =>
+        updateTimelineAchievementPosts(old, (posts) =>
+          posts.map((post) =>
+            post.id === input.achievementPostId
               ? { ...post, reactions: reactions }
-              : post;
-          }),
-        };
-      });
+              : post
+          )
+        )
+      );
       queryClient.setQueryData(
         ["user", input.userUsername],
         (old: HydratedUser) => {
@@ -480,17 +510,15 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
       return response.data.comments;
     },
     onSuccess: (comments, input) => {
-      queryClient.setQueryData(["timeline"], (old: TimelineData) => {
-        if (!old) return queryClient.refetchQueries({ queryKey: ["timeline"] });
-        return {
-          ...old,
-          achievementPosts: old.achievementPosts?.map((post) => {
-            return post.id === input.achievementPostId
+      queryClient.setQueryData(["timeline"], (old: TimelineCache | undefined) =>
+        updateTimelineAchievementPosts(old, (posts) =>
+          posts.map((post) =>
+            post.id === input.achievementPostId
               ? { ...post, comments: comments }
-              : post;
-          }),
-        };
-      });
+              : post
+          )
+        )
+      );
       queryClient.setQueryData(
         ["user", input.userUsername],
         (old: HydratedUser) => {
@@ -528,17 +556,15 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
       return response.data.comments;
     },
     onSuccess: (comments, input) => {
-      queryClient.setQueryData(["timeline"], (old: TimelineData) => {
-        if (!old) return queryClient.refetchQueries({ queryKey: ["timeline"] });
-        return {
-          ...old,
-          achievementPosts: old.achievementPosts?.map((post) => {
-            return post.id === input.achievementPostId
+      queryClient.setQueryData(["timeline"], (old: TimelineCache | undefined) =>
+        updateTimelineAchievementPosts(old, (posts) =>
+          posts.map((post) =>
+            post.id === input.achievementPostId
               ? { ...post, comments: comments }
-              : post;
-          }),
-        };
-      });
+              : post
+          )
+        )
+      );
       queryClient.setQueryData(
         ["user", input.userUsername],
         (old: HydratedUser) => {
@@ -573,15 +599,11 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
     },
     onSuccess: (_, input) => {
       // Remove from timeline data
-      queryClient.setQueryData(["timeline"], (old: TimelineData) => {
-        if (!old) return queryClient.refetchQueries({ queryKey: ["timeline"] });
-        return {
-          ...old,
-          achievementPosts: old.achievementPosts?.filter(
-            (post) => post.id !== input.achievementPostId
-          ),
-        };
-      });
+      queryClient.setQueryData(["timeline"], (old: TimelineCache | undefined) =>
+        updateTimelineAchievementPosts(old, (posts) =>
+          posts.filter((post) => post.id !== input.achievementPostId)
+        )
+      );
       // Remove from user data
       queryClient.setQueryData(
         ["user", input.userUsername],

--- a/apps/frontend-vite/src/contexts/timeline/index.tsx
+++ b/apps/frontend-vite/src/contexts/timeline/index.tsx
@@ -3,13 +3,10 @@
 
 import { useApiWithAuth } from "@/api";
 import { useSession } from "@/contexts/auth";
-import { normalizeApiResponse } from "@/utils/dateUtils";
-import { useQuery } from "@tanstack/react-query";
-import type { Activity } from "@tsw/prisma";
-import React from "react";
-import { getTimelineData, type TimelineAchievementPost, type TimelineActivityEntry, type TimelineUser } from "./service";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import React, { useMemo } from "react";
+import { getTimelineData, type TimelineData } from "./service";
 import { TimelineContext, type TimelineContextType } from "./types";
-import { normalizePlanProgress } from "../plans-progress/service";
 
 export const TimelineProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -17,54 +14,47 @@ export const TimelineProvider: React.FC<{ children: React.ReactNode }> = ({
   const { isSignedIn, isLoaded } = useSession();
   const api = useApiWithAuth();
 
-  const timelineQuery = useQuery({
+  const timelineQuery = useInfiniteQuery({
     queryKey: ["timeline"],
-    queryFn: () => getTimelineData(api),
-    select: (data) => ({
-      recommendedActivityEntries: data.recommendedActivityEntries.map(entry =>
-        normalizeApiResponse<TimelineActivityEntry>(entry, [
-          "date",
-          "createdAt",
-          "updatedAt",
-          "deletedAt",
-          "comments.createdAt",
-          "comments.deletedAt",
-          "reactions.createdAt",
-        ])
-      ),
-      recommendedActivities: data.recommendedActivities.map(activity =>
-        normalizeApiResponse<Activity>(activity, [
-          "createdAt",
-          "updatedAt",
-          "deletedAt",
-        ])
-      ),
-      recommendedUsers: data.recommendedUsers.map(user => ({
-        ...normalizeApiResponse<TimelineUser>(user, [
-          "plans.createdAt",
-          "plans.updatedAt",
-          "plans.finishingDate",
-        ]),
-        plans: user.plans.map(plan => ({
-          ...plan,
-          progress: normalizePlanProgress(plan.progress)
-        }))
-      })),
-      achievementPosts: data.achievementPosts.map(achievementPost =>
-        normalizeApiResponse<TimelineAchievementPost>(achievementPost, [
-          "createdAt",
-          "updatedAt",
-          "deletedAt",
-        ])
-      ),
-    }),
+    queryFn: ({ pageParam }) => getTimelineData(api, pageParam),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor || undefined,
     enabled: isLoaded && isSignedIn,
   });
 
+  const timelineData = useMemo<TimelineData | undefined>(() => {
+    if (!timelineQuery.data?.pages.length) return undefined;
+
+    const activityMap = new Map<string, TimelineData["recommendedActivities"][number]>();
+    const userMap = new Map<string, TimelineData["recommendedUsers"][number]>();
+
+    timelineQuery.data.pages.forEach((page) => {
+      page.recommendedActivities.forEach((activity) => activityMap.set(activity.id, activity));
+      page.recommendedUsers.forEach((user) => userMap.set(user.id, user));
+    });
+
+    return {
+      recommendedActivityEntries: timelineQuery.data.pages.flatMap(
+        (page) => page.recommendedActivityEntries
+      ),
+      recommendedActivities: Array.from(activityMap.values()),
+      recommendedUsers: Array.from(userMap.values()),
+      achievementPosts: timelineQuery.data.pages.flatMap(
+        (page) => page.achievementPosts
+      ),
+      nextCursor:
+        timelineQuery.data.pages[timelineQuery.data.pages.length - 1]
+          ?.nextCursor ?? null,
+    };
+  }, [timelineQuery.data]);
+
   const context: TimelineContextType = {
-    timelineData: timelineQuery.data,
+    timelineData,
     isLoadingTimeline: timelineQuery.isLoading,
     timelineError: timelineQuery.error,
+    isFetchingNextTimelinePage: timelineQuery.isFetchingNextPage,
+    hasMoreTimeline: timelineQuery.hasNextPage,
+    fetchNextTimelinePage: timelineQuery.fetchNextPage,
   };
 
   return (

--- a/apps/frontend-vite/src/contexts/timeline/service.ts
+++ b/apps/frontend-vite/src/contexts/timeline/service.ts
@@ -124,9 +124,12 @@ export interface TimelineData {
   recommendedActivities: Activity[];
   recommendedUsers: TimelineUser[];
   achievementPosts: TimelineAchievementPost[];
+  nextCursor?: string | null;
 }
 
-function normalizeActivityEntry(
+export type TimelinePage = TimelineData;
+
+export function normalizeActivityEntry(
   entry: TimelineActivityEntry
 ): TimelineActivityEntry {
   return normalizeApiResponse<TimelineActivityEntry>(entry, [
@@ -179,9 +182,15 @@ export function normalizeAchievementPost(
 }
 
 export async function getTimelineData(
-  api: AxiosInstance
-): Promise<TimelineData> {
-  const response = await api.get<TimelineData>("/users/timeline");
+  api: AxiosInstance,
+  cursor?: string | null
+): Promise<TimelinePage> {
+  const response = await api.get<TimelinePage>("/users/timeline", {
+    params: {
+      limit: 20,
+      ...(cursor ? { cursor } : {}),
+    },
+  });
   const data = response.data;
 
   return {
@@ -191,5 +200,6 @@ export async function getTimelineData(
     recommendedActivities: data.recommendedActivities.map(normalizeActivity),
     recommendedUsers: data.recommendedUsers.map(normalizeUser),
     achievementPosts: (data.achievementPosts || []).map(normalizeAchievementPost),
+    nextCursor: data.nextCursor ?? null,
   };
 }

--- a/apps/frontend-vite/src/contexts/timeline/types.ts
+++ b/apps/frontend-vite/src/contexts/timeline/types.ts
@@ -5,6 +5,9 @@ export interface TimelineContextType {
   timelineData: TimelineData | undefined;
   timelineError: Error | null;
   isLoadingTimeline: boolean;
+  isFetchingNextTimelinePage: boolean;
+  hasMoreTimeline: boolean;
+  fetchNextTimelinePage: () => Promise<unknown>;
 }
 
 export const TimelineContext = createContext<TimelineContextType | undefined>(

--- a/packages/prisma/migrations/20260512120000_add_timeline_pagination_indexes/migration.sql
+++ b/packages/prisma/migrations/20260512120000_add_timeline_pagination_indexes/migration.sql
@@ -1,0 +1,6 @@
+-- Improve timeline pagination queries over connected users.
+CREATE INDEX IF NOT EXISTS "activity_entries_userId_deletedAt_datetime_id_idx"
+ON "public"."activity_entries"("userId", "deletedAt", "datetime" DESC, "id" DESC);
+
+CREATE INDEX IF NOT EXISTS "achievement_posts_userId_deletedAt_createdAt_id_idx"
+ON "public"."achievement_posts"("userId", "deletedAt", "createdAt" DESC, "id" DESC);

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -185,6 +185,7 @@ model ActivityEntry {
 
   @@index([userId, deletedAt])
   @@index([userId, datetime, deletedAt])
+  @@index([userId, deletedAt, datetime, id])
   @@index([deletedAt, createdAt])
   @@index([activityId])
   @@index([createdAt])
@@ -256,6 +257,7 @@ model AchievementPost {
   @@index([planId])
   @@index([createdAt])
   @@index([deletedAt, createdAt])
+  @@index([userId, deletedAt, createdAt, id])
   @@map("achievement_posts")
   @@schema("public")
 }


### PR DESCRIPTION
#### Problem
Timeline rendering is slow because the API returns too much data up front.

Production Caddy logs showed successful `GET /users/timeline` responses taking roughly 3.8-4.4s with ~145-147KB response bodies, plus repeated client-aborted requests around 18-30s. The endpoint was fetching up to 50 activity entries and 50 achievement posts, including all comments, reaction user profiles, and progress for every visible user plan.

That made the first timeline paint expensive and caused the frontend to repeatedly scan large arrays while rendering cards.

### Fixes
- Paginate `GET /users/timeline` with a capped first page (`limit`, max 30) and stable `nextCursor`.
- Limit timeline comment hydration to the latest 2 comments per activity/achievement card.
- Add lazy comment loaders for full activity and achievement comment threads.
- Move the frontend timeline context to `useInfiniteQuery` and add an intersection-observer load-more sentinel.
- Deduplicate merged timeline pages client-side and preserve existing timeline cache updates for mutations.
- Build lookup maps in `TimelineRenderer` to avoid repeated linear searches per card render.
- Add database indexes for timeline pagination order on activity entries and achievement posts.

#### References
- Pulled latest `origin/main` before branching: already up to date.
- Production baseline from Caddy logs: `/users/timeline` success responses around `3.759s`, `4.065s`, `4.381s`, `4.411s`; aborted requests observed around `18.17s`, `29.33s`, `29.97s`, `30.20s`.
- New endpoint shape reduces initial timeline objects from up to 100 mixed posts with all comments to 20 mixed posts with at most 2 comments each.
- `pnpm --config.engine-strict=false --filter backend-node build` passed.
- `pnpm --config.engine-strict=false --filter frontend-vite build` passed. Existing frontend build warnings remain for router code-splitting, Prisma type re-exports, chunk size, and Serwist precache size.

#### Limitations
- I did not run a live before/after timing against production because this branch has not been deployed yet.
- The Prisma migration needs to run in the deployment pipeline before the new indexes help production queries.
- Cursor pagination uses timestamp plus id ordering across activity entries and achievement posts.
