### PR TITLE
Fix Hetzner backend healthcheck

### DIFF
--- a/hetzner/docker-compose.yml
+++ b/hetzner/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     networks:
       - web
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/health"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
#### Problem
The Hetzner backend container reports unhealthy even though the API is serving traffic.

After deploying the timeline pagination PR, `https://api.tracking.so/health` returned 200 consistently, but `docker compose ps` showed `tsw-backend` as unhealthy. Inspecting the healthcheck showed repeated `wget: can't connect to remote host: Connection refused`.

Inside the container, `wget http://localhost:3000/health` fails while `wget http://127.0.0.1:3000/health` succeeds because the app listens on IPv4 `0.0.0.0:3000`.

### Fixes
- Change the Hetzner backend Docker healthcheck from `localhost` to `127.0.0.1`.

#### References
- External health check: `https://api.tracking.so/health` returned HTTP 200 repeatedly with TLS verification OK.
- Container test: `wget -qO- http://127.0.0.1:3000/health` returned `{"status":"ok"}`.
- `ss -ltnp` inside the container showed Node listening on `0.0.0.0:3000`.

#### Limitations
- This only fixes Docker health reporting; it does not change application behavior.
