### PR TITLE
Optimize activity logging UX performance

### DIFF
--- a/apps/backend-node/src/routes/activities.ts
+++ b/apps/backend-node/src/routes/activities.ts
@@ -336,6 +336,11 @@ router.get(
   requireAuth,
   async (req: AuthenticatedRequest, res: Response) => {
     try {
+      const since = req.query.since as string | undefined;
+      const sinceDate = since
+        ? new Date(since)
+        : new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+
       const entries = await prisma.activityEntry.findMany({
         where: {
           userId: req.user!.id,
@@ -344,6 +349,7 @@ router.get(
           activity: {
             deletedAt: null,
           },
+          datetime: { gte: sinceDate },
         },
         include: {
           comments: {
@@ -470,7 +476,7 @@ router.post(
         });
       }
 
-      // Handle photo upload if provided
+      // Handle photo upload (must complete before response — entry needs image URLs)
       if (photos.length > 0) {
         try {
           const uploadedImages = await uploadActivityEntryPhotos(
@@ -479,7 +485,6 @@ router.post(
             entry.id
           );
 
-          // Update entry with image information
           entry = await prisma.activityEntry.update({
             where: { id: entry.id },
             data: buildActivityEntryImageUpdate(
@@ -492,132 +497,12 @@ router.post(
           logger.info(
             `${uploadedImages.length} photo(s) uploaded successfully to S3 for activity entry ${entry.id}`
           );
-
-          // Create notifications for connected users about the photo
-          const userWithConnections = await prisma.user.findUnique({
-            where: { id: req.user!.id },
-            include: {
-              connectionsFrom: {
-                where: { status: "ACCEPTED" },
-                include: { to: true },
-              },
-              connectionsTo: {
-                where: { status: "ACCEPTED" },
-                include: { from: true },
-              },
-            },
-          });
-
-          if (userWithConnections) {
-            const connectedUsers = [
-              ...userWithConnections.connectionsFrom.map((conn) => conn.to),
-              ...userWithConnections.connectionsTo.map((conn) => conn.from),
-            ];
-
-            for (const connectedUser of connectedUsers) {
-              const message = `${req.user!.username} logged ${quantity} ${activity.measure} of ${activity.emoji} ${activity.title} with ${uploadedImages.length === 1 ? "a photo" : `${uploadedImages.length} photos`} 📸!`;
-              await notificationService.createAndProcessNotification({
-                userId: connectedUser.id,
-                message,
-                type: "INFO",
-                relatedId: entry.id,
-                relatedData: {
-                  activityEntryId: entry.id,
-                  userPicture: req.user!.picture,
-                  userName: req.user!.name,
-                  userUsername: req.user!.username,
-                },
-              });
-            }
-          }
         } catch (error) {
           logger.error("Error uploading photo to S3:", error);
-          // Continue without photo - don't fail the entire activity logging
-        }
-      } else {
-        logger.info("No photo provided");
-      }
-
-      // Update user's last active time
-      await prisma.user.update({
-        where: { id: req.user!.id },
-        data: {
-          lastActiveAt: new Date(),
-        },
-      });
-
-      // TODO: Add plan state processing
-      const plans = await prisma.plan.findMany({
-        where: {
-          userId: req.user!.id,
-          activities: {
-            some: {
-              id: activityId,
-            },
-          },
-        },
-      });
-
-      // Invalidate progress cache for affected plans
-      if (plans.length > 0) {
-        await plansService.invalidateUserPlanProgressCaches(req.user!.id, [
-          activityId,
-        ]);
-      }
-
-      // Find coached plan and recalculate its state
-      for (const plan of plans) {
-        if (plan.isCoached) {
-          // only coach the coached plan
-          plansService.recalculateCurrentWeekState(plan, req.user!);
-
-          // Schedule post-activity celebration message (30-90 seconds after logging)
-          // Use a random delay to make it feel more natural
-          const delayMs = 30000 + Math.random() * 60000; // 30s to 90s
-          setTimeout(async () => {
-            try {
-              // Fetch fresh plan data with activities
-              const planWithActivities = await prisma.plan.findUnique({
-                where: { id: plan.id },
-                include: { activities: true },
-              });
-
-              if (planWithActivities) {
-                await plansService.processPostActivityCoaching(
-                  req.user!,
-                  planWithActivities,
-                  entry
-                );
-              }
-            } catch (error) {
-              logger.error(
-                `Error in delayed post-activity coaching for user ${req.user!.username}:`,
-                error
-              );
-              // Silently fail - don't affect the user experience
-            }
-          }, delayMs);
-
-          logger.info(
-            `Scheduled post-activity coaching for user ${req.user!.username} in ${Math.round(delayMs / 1000)}s`
-          );
-        } else {
-          logger.info(`Plan '${plan.goal}' is not coached, skipping`);
         }
       }
 
-      // Invalidate progress cache for all plans using this activity
-      // This ensures the next fetch will recompute progress with fresh data
-      await prisma.plan.updateMany({
-        where: {
-          userId: req.user!.id,
-          activities: {
-            some: { id: activityId },
-          },
-        },
-        data: { progressCalculatedAt: null },
-      });
-
+      // Handle shared activity invite (must complete before response — may return 400)
       let sharedActivityInvite: Awaited<ReturnType<typeof createPendingSharedActivityInvite>> | null = null;
       if (normalizedWithUserId) {
         try {
@@ -634,8 +519,106 @@ router.post(
         }
       }
 
-      const sharedActivityCandidates = await findSharedActivityCandidates(entry.id, req.user!.id);
-      res.json({ ...entry, entry, sharedActivityCandidates, sharedActivityInvite });
+      // Respond immediately — defer all non-critical work
+      res.json({ ...entry, entry, sharedActivityInvite });
+
+      // --- Fire-and-forget: notifications, plan processing, cache invalidation ---
+      const user = req.user!;
+      const entryId = entry.id;
+      setImmediate(async () => {
+        try {
+          // Photo notifications
+          if (photos.length > 0) {
+            const userWithConnections = await prisma.user.findUnique({
+              where: { id: user.id },
+              include: {
+                connectionsFrom: {
+                  where: { status: "ACCEPTED" },
+                  include: { to: true },
+                },
+                connectionsTo: {
+                  where: { status: "ACCEPTED" },
+                  include: { from: true },
+                },
+              },
+            });
+
+            if (userWithConnections) {
+              const connectedUsers = [
+                ...userWithConnections.connectionsFrom.map((conn) => conn.to),
+                ...userWithConnections.connectionsTo.map((conn) => conn.from),
+              ];
+
+              const uploadedCount = (entry.imageUrls as string[] | null)?.length || 1;
+              for (const connectedUser of connectedUsers) {
+                const message = `${user.username} logged ${quantity} ${activity.measure} of ${activity.emoji} ${activity.title} with ${uploadedCount === 1 ? "a photo" : `${uploadedCount} photos`} 📸!`;
+                await notificationService.createAndProcessNotification({
+                  userId: connectedUser.id,
+                  message,
+                  type: "INFO",
+                  relatedId: entryId,
+                  relatedData: {
+                    activityEntryId: entryId,
+                    userPicture: user.picture,
+                    userName: user.name,
+                    userUsername: user.username,
+                  },
+                });
+              }
+            }
+          }
+
+          // Update user's last active time
+          await prisma.user.update({
+            where: { id: user.id },
+            data: { lastActiveAt: new Date() },
+          });
+
+          // Plan processing
+          const plans = await prisma.plan.findMany({
+            where: {
+              userId: user.id,
+              activities: { some: { id: activityId } },
+            },
+          });
+
+          if (plans.length > 0) {
+            await plansService.invalidateUserPlanProgressCaches(user.id, [activityId]);
+          }
+
+          for (const plan of plans) {
+            if (plan.isCoached) {
+              plansService.recalculateCurrentWeekState(plan, user);
+
+              const delayMs = 30000 + Math.random() * 60000;
+              setTimeout(async () => {
+                try {
+                  const planWithActivities = await prisma.plan.findUnique({
+                    where: { id: plan.id },
+                    include: { activities: true },
+                  });
+
+                  if (planWithActivities) {
+                    await plansService.processPostActivityCoaching(user, planWithActivities, entry);
+                  }
+                } catch (error) {
+                  logger.error(`Error in delayed post-activity coaching for user ${user.username}:`, error);
+                }
+              }, delayMs);
+            }
+          }
+
+          await prisma.plan.updateMany({
+            where: {
+              userId: user.id,
+              activities: { some: { id: activityId } },
+            },
+            data: { progressCalculatedAt: null },
+          });
+        } catch (error) {
+          logger.error("Error in deferred log-activity work:", error);
+        }
+      });
     } catch (error) {
       logger.error("Error logging activity:", error);
       res.status(500).json({ error: "Failed to log activity" });

--- a/apps/frontend-vite/package.json
+++ b/apps/frontend-vite/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@capacitor/core": "^7.4.3",
+    "@capacitor/geolocation": "^7.1.8",
     "@capacitor/ios": "^7.4.3",
     "@capacitor/local-notifications": "^7.0.3",
     "@capacitor/push-notifications": "^7.0.3",
@@ -63,6 +64,7 @@
     "html-to-image": "^1.11.13",
     "js-confetti": "^0.13.1",
     "lucide-react": "^0.451.0",
+    "mapbox-gl": "^3.24.0",
     "motion": "^12.23.12",
     "posthog-js": "^1.181.0",
     "react": "^19.1.1",

--- a/apps/frontend-vite/src/components/ActivityPhotoUploader.tsx
+++ b/apps/frontend-vite/src/components/ActivityPhotoUploader.tsx
@@ -33,7 +33,7 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
 }) => {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [description, setDescription] = useState("");
-  const { logActivity: submitActivity, isLoggingActivity } = useActivities();
+  const { logActivity: submitActivity, isLoggingActivity, getSharedActivityCandidates } = useActivities();
   const { addToNotificationCount } = useNotifications();
 
   const handleLogActivity = async () => {
@@ -52,7 +52,16 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
       }
 
       addToNotificationCount(1, "profile");
-      onSuccess(response.entry.id, response.sharedActivityCandidates || []);
+
+      // Fetch shared candidates lazily — don't block the log response on this
+      const candidates = response.sharedActivityCandidates || [];
+      if (candidates.length > 0) {
+        onSuccess(response.entry.id, candidates);
+      } else {
+        getSharedActivityCandidates(response.entry.id)
+          .then((lazyCandidates) => onSuccess(response.entry.id, lazyCandidates || []))
+          .catch(() => onSuccess(response.entry.id, []));
+      }
     } catch (error: any) {
       console.error("Error logging activity:", error);
       toast.error("Failed to log activity. Please try again.");

--- a/apps/frontend-vite/src/contexts/activities/provider.tsx
+++ b/apps/frontend-vite/src/contexts/activities/provider.tsx
@@ -127,9 +127,8 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
       const response = await api.post("/activities/log-activity", formData);
       return response.data;
     },
-    onSuccess: async (response: LogActivityResponse, variables) => {
+    onSuccess: (response: LogActivityResponse, variables) => {
       const entry = response.entry;
-      queryClient.refetchQueries({ queryKey: ["current-user"] });
       queryClient.setQueryData(
         ["activity-entries"],
         (old: ReturnedActivityEntriesType) => {
@@ -140,15 +139,6 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
           return [...old, entry];
         }
       );
-      queryClient.invalidateQueries({ queryKey: ["activity-entries"] });
-      queryClient.invalidateQueries({ queryKey: ["timeline"] });
-      queryClient.invalidateQueries({ queryKey: ["notifications"] });
-      queryClient.invalidateQueries({ queryKey: ["metrics"] });
-      queryClient.invalidateQueries({ queryKey: ["plan-group-progress"] });
-
-      // Refetch plans and WAIT for it - this ensures fresh progress data
-      // is available for achievement detection
-      await queryClient.refetchQueries({ queryKey: ["plans"] });
 
       const hasPhoto = !!variables.photo || !!variables.photos?.length;
       toast.success(
@@ -156,6 +146,15 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
           ? "Activity logged with photo successfully!"
           : "Activity logged successfully!"
       );
+
+      // Background invalidations — none of these block the UI
+      queryClient.invalidateQueries({ queryKey: ["activity-entries"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+      queryClient.invalidateQueries({ queryKey: ["metrics"] });
+      queryClient.invalidateQueries({ queryKey: ["plans"] });
+      queryClient.invalidateQueries({ queryKey: ["plan-group-progress"] });
+      queryClient.invalidateQueries({ queryKey: ["current-user"] });
     },
     onError: (error) => {
       const customErrorMessage = `Failed to log activity`;
@@ -212,16 +211,14 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
 
       await api.put(`/activities/activity-entries/${data.entry.id}`, payload);
     },
-    onSuccess: async (_, { muteNotification }) => {
-      queryClient.refetchQueries({ queryKey: ["activity-entries"] });
-      queryClient.refetchQueries({ queryKey: ["timeline"] });
-
-      // Refetch plans to update progress after entry update
-      await queryClient.refetchQueries({ queryKey: ["plans"] });
-
+    onSuccess: (_, { muteNotification }) => {
       if (!muteNotification) {
         toast.success("Activity updated successfully!");
       }
+
+      queryClient.invalidateQueries({ queryKey: ["activity-entries"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      queryClient.invalidateQueries({ queryKey: ["plans"] });
     },
     onError: (error, { muteNotification }) => {
       const customErrorMessage = `Failed to update activity`;
@@ -237,7 +234,7 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
       await api.delete(`/activities/${data.id}`);
       return data.id;
     },
-    onSuccess: async (id) => {
+    onSuccess: (id) => {
       queryClient.setQueryData(
         ["activities"],
         (old: ReturnedActivitiesType) => {
@@ -246,12 +243,11 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
           return old.filter((activity) => activity.id !== id);
         }
       );
-      queryClient.refetchQueries({ queryKey: ["timeline"] });
-
-      // Refetch plans to update progress after activity deletion
-      await queryClient.refetchQueries({ queryKey: ["plans"] });
 
       toast.success("Activity deleted successfully!");
+
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      queryClient.invalidateQueries({ queryKey: ["plans"] });
     },
     onError: (error) => {
       const customErrorMessage = `Failed to delete activity`;
@@ -264,7 +260,7 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
       await api.delete(`/activities/activity-entries/${data.id}`);
       return data;
     },
-    onSuccess: async ({ id }) => {
+    onSuccess: ({ id }) => {
       queryClient.setQueryData(
         ["activity-entries"],
         (old: ReturnedActivityEntriesType) => {
@@ -281,10 +277,9 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
         )
       );
 
-      // Refetch plans to update progress after entry deletion
-      await queryClient.refetchQueries({ queryKey: ["plans"] });
-
       toast.success("Activity deleted successfully!");
+
+      queryClient.invalidateQueries({ queryKey: ["plans"] });
     },
     onError: (error) => {
       const customErrorMessage = `Failed to delete activity entry`;

--- a/apps/frontend-vite/src/contexts/activities/service.ts
+++ b/apps/frontend-vite/src/contexts/activities/service.ts
@@ -60,9 +60,10 @@ export async function getActivities(api: AxiosInstance) {
   return response.data;
 }
 
-export async function getActivitiyEntries(api: AxiosInstance) {
+export async function getActivitiyEntries(api: AxiosInstance, sinceDays = 90) {
+  const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000).toISOString();
   const response = await api.get<ActivityEntryWithRelations[]>(
-    "/activities/activity-entries"
+    `/activities/activity-entries?since=${since}`
   );
   return response.data;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
       '@capacitor/core':
         specifier: ^7.4.3
         version: 7.4.3
+      '@capacitor/geolocation':
+        specifier: ^7.1.8
+        version: 7.1.8(@capacitor/core@7.4.3)
       '@capacitor/ios':
         specifier: ^7.4.3
         version: 7.4.3(@capacitor/core@7.4.3)
@@ -384,6 +387,9 @@ importers:
       lucide-react:
         specifier: ^0.451.0
         version: 0.451.0(react@19.1.1)
+      mapbox-gl:
+        specifier: ^3.24.0
+        version: 3.24.0
       motion:
         specifier: ^12.23.12
         version: 12.23.12(@emotion/is-prop-valid@0.8.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -1003,6 +1009,11 @@ packages:
   '@capacitor/core@7.4.3':
     resolution: {integrity: sha512-wCWr8fQ9Wxn0466vPg7nMn0tivbNVjNy1yL4GvDSIZuZx7UpU2HeVGNe9QjN/quEd+YLRFeKEBLBw619VqUiNg==}
 
+  '@capacitor/geolocation@7.1.8':
+    resolution: {integrity: sha512-x/rJieD2N2zlGvXFRD3ru4ArJWTwXAIYmyhfo5zg4F1DKGos7mCCOvIOSVMdfQmt14SCsmJeO9Qe8EtDGNGCrw==}
+    peerDependencies:
+      '@capacitor/core': '>=7.0.0'
+
   '@capacitor/ios@7.4.3':
     resolution: {integrity: sha512-VNm7cHODgh3KK/4ZC2rXU9gBlvHii/mYFLI+XMXwq24nhB679QxHhz+pUuI7PatYoM2q4MAL0NR/dRgehKCaSA==}
     peerDependencies:
@@ -1017,6 +1028,9 @@ packages:
     resolution: {integrity: sha512-4qt5dRVBkHzq202NEoj3JC+S+zQCrZ1FJh7sjkICy/i1iEos+VaoB3bie8eWDQ2LTARktB4+k2xkdpu8pcVo/g==}
     peerDependencies:
       '@capacitor/core': '>=7.0.0'
+
+  '@capacitor/synapse@1.0.4':
+    resolution: {integrity: sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==}
 
   '@capawesome/capacitor-badge@7.0.1':
     resolution: {integrity: sha512-jhVieRRVLgGO1NU7PW8uWZmf3WD4IsYUlkrJ82KuoRgLFx1tbJGwHU1ro0sUJmEwfLO9vldhBnJJ/J5nHrjbQQ==}
@@ -1045,6 +1059,7 @@ packages:
   '@clerk/clerk-react@5.12.0':
     resolution: {integrity: sha512-3Lr2QazCm5R6ZLbu7wM+d5YwCElrAoX00OBWcKqjPYaWDJCCmEYN6LJbLzOTYQ8QT1J1ZIed85/lKa+q2aD1aA==}
     engines: {node: '>=18.17.0'}
+    deprecated: 'This package is no longer supported. Please use @clerk/react instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
     peerDependencies:
       react: '>=18 || >=19.0.0-beta'
       react-dom: '>=18 || >=19.0.0-beta'
@@ -1094,14 +1109,17 @@ packages:
   '@clerk/types@3.65.5':
     resolution: {integrity: sha512-RGO8v2a52Ybo1jwVj42UWT8VKyxAk/qOxrkA3VNIYBNEajPSmZNa9r9MTgqSgZRyz1XTlQHdVb7UK7q78yAGfA==}
     engines: {node: '>=14'}
+    deprecated: 'This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
 
   '@clerk/types@4.26.0':
     resolution: {integrity: sha512-VGcrQz/XpCiGbpIIzKVwWw4nLorzKnIP1IAemj1xt/80ULcdEZCncwhas6PoYBBsl1W55A1SwP9B/pEs0nmkCw==}
     engines: {node: '>=18.17.0'}
+    deprecated: 'This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
 
   '@clerk/types@4.72.0':
     resolution: {integrity: sha512-SEkgiQNeTstC0/mQjHCGBEyX0/ALyWAa5QZBBvVOok204r48MLipfIKsXQhyWE2Hk6FIo5WT6YyqD36jaxUEIw==}
     engines: {node: '>=18.17.0'}
+    deprecated: 'This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -1940,9 +1958,24 @@ packages:
     resolution: {integrity: sha512-LyQz4XJIdCdY/+temIhD/Ed0x/p4GAOUycpFSEK2Ads1CPKZy6b7V/2ROEtQiLLQ8soIs0xe/QAoR6kwpyW/yw==}
     engines: {node: '>=12'}
 
+  '@mapbox/mapbox-gl-supported@3.0.0':
+    resolution: {integrity: sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==}
+
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/vector-tile@2.0.4':
+    resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2485,6 +2518,7 @@ packages:
 
   '@react-grab/claude-code@0.0.97':
     resolution: {integrity: sha512-q9wqnDymTb4zNZnVEP1nuf7hrMIserb6DzvhzCsFvNHpmwMrf8KCMYnttQrZkhC7MJZIedJBk9TzqtOnVrFq5Q==}
+    deprecated: 'Deprecated: use @react-grab/mcp instead'
     hasBin: true
 
   '@rolldown/pluginutils@1.0.0-beta.35':
@@ -3267,6 +3301,12 @@ packages:
   '@types/fs-extra@8.1.5':
     resolution: {integrity: sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==}
 
+  '@types/geojson-vt@3.2.5':
+    resolution: {integrity: sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
@@ -3342,6 +3382,9 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/pbf@3.0.5':
+    resolution: {integrity: sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==}
+
   '@types/phoenix@1.6.6':
     resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
 
@@ -3400,6 +3443,9 @@ packages:
   '@types/stripe@8.0.417':
     resolution: {integrity: sha512-PTuqskh9YKNENnOHGVJBm4sM0zE8B1jZw1JIskuGAPkMB+OH236QeN8scclhYGPA4nG6zTtPXgwpXdp+HPDTVw==}
     deprecated: This is a stub types definition. stripe provides its own type definitions, so you do not need this installed.
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
@@ -3565,6 +3611,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
@@ -4057,6 +4104,9 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  cheap-ruler@4.0.0:
+    resolution: {integrity: sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==}
+
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
@@ -4250,6 +4300,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csscolorparser@1.0.3:
+    resolution: {integrity: sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==}
 
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
@@ -4509,6 +4562,9 @@ packages:
 
   dynamic-dedupe@0.3.0:
     resolution: {integrity: sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==}
+
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -5013,6 +5069,9 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  geojson-vt@4.0.3:
+    resolution: {integrity: sha512-jR1MwkLaZGa8Zftct9ZFruyWFrdl9ZyD2OliXNy9Qq5bBPeg5wHVpBQF9p5GjnicSDQqvBVpysxTPKmWdsfWMA==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -5051,6 +5110,9 @@ packages:
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
+
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -5661,6 +5723,9 @@ packages:
   jws@4.0.0:
     resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
 
+  kdbush@4.0.2:
+    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -5856,6 +5921,12 @@ packages:
   map-obj@4.3.0:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
+
+  mapbox-gl@3.24.0:
+    resolution: {integrity: sha512-R+FdFUB3DnoE5FYASV7lGSiRyMkSblcZ2UEy7b2pt7s5ZbCxFIUPXd0E6iAFd8OdvdA2VtbvZZVylzAZNaurjA==}
+
+  martinez-polygon-clipping@0.8.1:
+    resolution: {integrity: sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -6112,6 +6183,9 @@ packages:
     resolution: {integrity: sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==}
     engines: {node: '>= 6.0.0'}
     deprecated: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   mylas@2.1.13:
     resolution: {integrity: sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==}
@@ -6386,6 +6460,10 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pbf@4.0.1:
+    resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
+    hasBin: true
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -6440,6 +6518,9 @@ packages:
         optional: true
       rrweb-snapshot:
         optional: true
+
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
 
   preact@10.27.0:
     resolution: {integrity: sha512-/DTYoB6mwwgPytiqQTh/7SFRL98ZdiD8Sk8zIUVOxtwq4oWcwrcd1uno9fE/zZmUaUrFNYzbH14CPebOz9tZQw==}
@@ -6499,6 +6580,9 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -6548,6 +6632,9 @@ packages:
   quick-lru@4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -6779,6 +6866,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
   resolve.exports@2.0.3:
     resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
     engines: {node: '>=10'}
@@ -6806,6 +6896,9 @@ packages:
     resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
     engines: {node: 20 || >=22}
     hasBin: true
+
+  robust-predicates@2.0.4:
+    resolution: {integrity: sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==}
 
   rollup@4.46.2:
     resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
@@ -7007,6 +7100,9 @@ packages:
   spdx-license-ids@3.0.22:
     resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
 
+  splaytree@0.1.4:
+    resolution: {integrity: sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -7124,6 +7220,9 @@ packages:
     resolution: {integrity: sha512-bjCdzcAzbzmPn5B4FNjsAE32aHDgCHtHngj0eDZdZ1+tVbH1/4TwGeZWy41JeiraNx5VPMG+BUOG2VNBXXcXEA==}
     engines: {npm: '>=8'}
     hasBin: true
+
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
 
   supermemory@4.11.1:
     resolution: {integrity: sha512-L5I/inWEIjtD+kw/2TAZ7ZsZa3kCYzlXXeNHd09ueFoExvCHLjzTW4SCnN6GjbhE7CZUcwTXA9SttZvihLa8gQ==}
@@ -7243,6 +7342,9 @@ packages:
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
@@ -8959,6 +9061,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@capacitor/geolocation@7.1.8(@capacitor/core@7.4.3)':
+    dependencies:
+      '@capacitor/core': 7.4.3
+      '@capacitor/synapse': 1.0.4
+
   '@capacitor/ios@7.4.3(@capacitor/core@7.4.3)':
     dependencies:
       '@capacitor/core': 7.4.3
@@ -8970,6 +9077,8 @@ snapshots:
   '@capacitor/push-notifications@7.0.3(@capacitor/core@7.4.3)':
     dependencies:
       '@capacitor/core': 7.4.3
+
+  '@capacitor/synapse@1.0.4': {}
 
   '@capawesome/capacitor-badge@7.0.1(@capacitor/core@7.4.3)':
     dependencies:
@@ -9855,6 +9964,8 @@ snapshots:
     dependencies:
       unist-util-visit: 1.4.1
 
+  '@mapbox/mapbox-gl-supported@3.0.0': {}
+
   '@mapbox/node-pre-gyp@1.0.11':
     dependencies:
       detect-libc: 2.0.4
@@ -9869,6 +9980,18 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.2.0': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/vector-tile@2.0.4':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.1
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -11351,6 +11474,12 @@ snapshots:
     dependencies:
       '@types/node': 24.5.2
 
+  '@types/geojson-vt@3.2.5':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/geojson@7946.0.16': {}
+
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 20.19.9
@@ -11436,6 +11565,8 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/pbf@3.0.5': {}
+
   '@types/phoenix@1.6.6': {}
 
   '@types/prop-types@15.7.15': {}
@@ -11493,6 +11624,10 @@ snapshots:
       stripe: 18.4.0(@types/node@20.19.9)
     transitivePeerDependencies:
       - '@types/node'
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/triple-beam@1.3.5': {}
 
@@ -12301,6 +12436,8 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  cheap-ruler@4.0.0: {}
+
   check-error@2.1.1: {}
 
   chokidar@3.6.0:
@@ -12485,6 +12622,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csscolorparser@1.0.3: {}
 
   cssstyle@4.6.0:
     dependencies:
@@ -12699,6 +12838,8 @@ snapshots:
   dynamic-dedupe@0.3.0:
     dependencies:
       xtend: 4.0.2
+
+  earcut@3.0.2: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -13374,6 +13515,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  geojson-vt@4.0.3: {}
+
   get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
@@ -13419,6 +13562,8 @@ snapshots:
       node-fetch-native: 1.6.7
       nypm: 0.6.1
       pathe: 2.0.3
+
+  gl-matrix@3.4.4: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -14238,6 +14383,8 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  kdbush@4.0.2: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -14395,6 +14542,37 @@ snapshots:
       tmpl: 1.0.5
 
   map-obj@4.3.0: {}
+
+  mapbox-gl@3.24.0:
+    dependencies:
+      '@mapbox/mapbox-gl-supported': 3.0.0
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.4
+      '@types/geojson': 7946.0.16
+      '@types/geojson-vt': 3.2.5
+      '@types/pbf': 3.0.5
+      '@types/supercluster': 7.1.3
+      cheap-ruler: 4.0.0
+      csscolorparser: 1.0.3
+      earcut: 3.0.2
+      geojson-vt: 4.0.3
+      gl-matrix: 3.4.4
+      kdbush: 4.0.2
+      martinez-polygon-clipping: 0.8.1
+      murmurhash-js: 1.0.0
+      pbf: 4.0.1
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      supercluster: 8.0.1
+      tinyqueue: 3.0.0
+
+  martinez-polygon-clipping@0.8.1:
+    dependencies:
+      robust-predicates: 2.0.4
+      splaytree: 0.1.4
+      tinyqueue: 3.0.0
 
   math-intrinsics@1.1.0: {}
 
@@ -14779,6 +14957,8 @@ snapshots:
       type-is: 1.6.18
       xtend: 4.0.2
 
+  murmurhash-js@1.0.0: {}
+
   mylas@2.1.13: {}
 
   nanoid@3.3.11: {}
@@ -15037,6 +15217,10 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pbf@4.0.1:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   pend@1.2.0: {}
 
   perfect-debounce@1.0.0: {}
@@ -15085,6 +15269,8 @@ snapshots:
       fflate: 0.4.8
       preact: 10.27.0
       web-vitals: 4.2.4
+
+  potpack@2.1.0: {}
 
   preact@10.27.0: {}
 
@@ -15138,6 +15324,8 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  protocol-buffers-schema@3.6.1: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -15174,6 +15362,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-lru@4.0.1: {}
+
+  quickselect@3.0.0: {}
 
   randombytes@2.1.0:
     dependencies:
@@ -15457,6 +15647,10 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
+
   resolve.exports@2.0.3: {}
 
   resolve@1.22.10:
@@ -15479,6 +15673,8 @@ snapshots:
     dependencies:
       glob: 11.0.3
       package-json-from-dist: 1.0.1
+
+  robust-predicates@2.0.4: {}
 
   rollup@4.46.2:
     dependencies:
@@ -15716,6 +15912,8 @@ snapshots:
 
   spdx-license-ids@3.0.22: {}
 
+  splaytree@0.1.4: {}
+
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
@@ -15823,6 +16021,10 @@ snapshots:
       tar: 7.4.3
     transitivePeerDependencies:
       - supports-color
+
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.0.2
 
   supermemory@4.11.1: {}
 
@@ -15949,6 +16151,8 @@ snapshots:
       picomatch: 4.0.3
 
   tinypool@1.1.1: {}
+
+  tinyqueue@3.0.0: {}
 
   tinyrainbow@1.2.0: {}
 


### PR DESCRIPTION
## Summary

- **Backend: Defer non-critical work in `/log-activity`** — photo notifications, `lastActiveAt` updates, plan processing, and cache invalidation now run via `setImmediate()` after the response is sent
- **Backend: Add `?since=` date filter to `/activity-entries`** — defaults to 90 days, reducing query time and payload size dramatically
- **Frontend: Remove blocking `await refetchQueries`** — all post-mutation query invalidations are now non-blocking, toast shows immediately
- **Frontend: Lazy-load shared activity candidates** — fetched via separate endpoint after log response instead of blocking the log request

## Performance (local DB with prod data, 5-run median)

| User (entries) | Old query | New query (90d) | Speedup | Old payload | New payload |
|---|---|---|---|---|---|
| liocas (513) | 25.9ms | 4.7ms | **5.5x** | 1005 KB | 95 KB |
| barbaraherbertt (386) | 22.6ms | 4.4ms | **5.1x** | 933 KB | 114 KB |
| alex (365) | 18.3ms | 2.9ms | **6.3x** | 763 KB | 52 KB |

Additionally, ~15ms of deferred work (plan lookups, lastActiveAt) per log request is now off the critical path. `findSharedActivityCandidates` (3-4 DB queries, variable latency) is also moved off the log-activity response.