### PR TITLE
fix: stop timeline infinite spinner on pagination errors

### DIFF
--- a/apps/frontend-vite/src/components/TimelineRenderer.tsx
+++ b/apps/frontend-vite/src/components/TimelineRenderer.tsx
@@ -52,6 +52,7 @@ const TimelineRenderer: React.FC<{
     timelineData,
     isLoadingTimeline,
     isFetchingNextTimelinePage,
+    isFetchNextTimelinePageError,
     hasMoreTimeline,
     fetchNextTimelinePage,
   } = useTimeline();
@@ -271,7 +272,7 @@ const TimelineRenderer: React.FC<{
   }, [timelineData?.recommendedUsers]);
 
   useEffect(() => {
-    if (!loadMoreRef.current || !hasMoreTimeline) return;
+    if (!loadMoreRef.current || !hasMoreTimeline || isFetchNextTimelinePageError) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -285,7 +286,12 @@ const TimelineRenderer: React.FC<{
 
     observer.observe(loadMoreRef.current);
     return () => observer.disconnect();
-  }, [fetchNextTimelinePage, hasMoreTimeline, isFetchingNextTimelinePage]);
+  }, [
+    fetchNextTimelinePage,
+    hasMoreTimeline,
+    isFetchingNextTimelinePage,
+    isFetchNextTimelinePageError,
+  ]);
 
   // Check if there will be a divider shown (new posts exist AND we have a lastViewedTimelineAt)
   const willShowDivider = useMemo(() => {
@@ -737,6 +743,24 @@ const TimelineRenderer: React.FC<{
       {isFetchingNextTimelinePage && (
         <div className="col-span-2 sm:col-span-4 flex justify-center py-4">
           <RefreshCcw className="w-4 h-4 animate-spin text-muted-foreground" />
+        </div>
+      )}
+      {isFetchNextTimelinePageError && !isFetchingNextTimelinePage && (
+        <div className="col-span-2 sm:col-span-4 flex flex-col items-center gap-2 py-4 text-center text-xs text-muted-foreground">
+          <span>Couldn&apos;t load more timeline items.</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 px-3 text-xs"
+            onClick={() => fetchNextTimelinePage()}
+          >
+            <RefreshCcw className="w-3 h-3 mr-2" /> Try again
+          </Button>
+        </div>
+      )}
+      {!hasMoreTimeline && !isFetchingNextTimelinePage && mergedTimelineItems.length > 0 && (
+        <div className="col-span-2 sm:col-span-4 py-4 text-center text-xs text-muted-foreground">
+          You&apos;re all caught up
         </div>
       )}
     </div>

--- a/apps/frontend-vite/src/contexts/timeline/index.tsx
+++ b/apps/frontend-vite/src/contexts/timeline/index.tsx
@@ -8,6 +8,25 @@ import React, { useMemo } from "react";
 import { getTimelineData, type TimelineData } from "./service";
 import { TimelineContext, type TimelineContextType } from "./types";
 
+export const getTimelineNextPageParam = (
+  lastPage: TimelineData,
+  allPages: TimelineData[]
+) => {
+  const nextCursor = lastPage.nextCursor || undefined;
+  if (!nextCursor) return undefined;
+
+  const returnedItems =
+    lastPage.recommendedActivityEntries.length + lastPage.achievementPosts.length;
+  if (returnedItems === 0) return undefined;
+
+  const previousPages = allPages.slice(0, -1);
+  if (previousPages.some((page) => page.nextCursor === nextCursor)) {
+    return undefined;
+  }
+
+  return nextCursor;
+};
+
 export const TimelineProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
@@ -18,7 +37,7 @@ export const TimelineProvider: React.FC<{ children: React.ReactNode }> = ({
     queryKey: ["timeline"],
     queryFn: ({ pageParam }) => getTimelineData(api, pageParam),
     initialPageParam: null as string | null,
-    getNextPageParam: (lastPage) => lastPage.nextCursor || undefined,
+    getNextPageParam: getTimelineNextPageParam,
     enabled: isLoaded && isSignedIn,
   });
 
@@ -53,6 +72,7 @@ export const TimelineProvider: React.FC<{ children: React.ReactNode }> = ({
     isLoadingTimeline: timelineQuery.isLoading,
     timelineError: timelineQuery.error,
     isFetchingNextTimelinePage: timelineQuery.isFetchingNextPage,
+    isFetchNextTimelinePageError: timelineQuery.isFetchNextPageError,
     hasMoreTimeline: timelineQuery.hasNextPage,
     fetchNextTimelinePage: timelineQuery.fetchNextPage,
   };

--- a/apps/frontend-vite/src/contexts/timeline/types.ts
+++ b/apps/frontend-vite/src/contexts/timeline/types.ts
@@ -6,6 +6,7 @@ export interface TimelineContextType {
   timelineError: Error | null;
   isLoadingTimeline: boolean;
   isFetchingNextTimelinePage: boolean;
+  isFetchNextTimelinePageError: boolean;
   hasMoreTimeline: boolean;
   fetchNextTimelinePage: () => Promise<unknown>;
 }


### PR DESCRIPTION
## Summary
- Stops automatic infinite-scroll retries when the bottom timeline page fetch errors, replacing the stuck spinner with a small retry state.
- Adds frontend pagination guards for missing cursors, empty pages, and duplicate cursors so malformed/end pages do not keep `hasNextPage` alive forever.
- Shows a compact "You're all caught up" end state on finite non-empty timelines.

## Root cause
The bottom sentinel remains visible after a next-page request fails. React Query preserves `hasNextPage` from the last successful page, and when `isFetchingNextPage` flips back to false the IntersectionObserver effect re-attaches and immediately calls `fetchNextPage()` again. That creates a fetch/spinner loop at the bottom of the mobile timeline. The frontend also trusted any backend `nextCursor`, so empty or duplicate-cursor pages could keep pagination alive.

## Test plan
- `pnpm --filter frontend-vite exec eslint src/contexts/timeline/index.tsx src/contexts/timeline/types.ts src/components/TimelineRenderer.tsx` (passes with existing TimelineRenderer warnings only; 0 errors)
- `git diff --check` (passes)
- `pnpm --filter frontend-vite build` (fails on unrelated existing `coachPersonality` type errors in coach screens/routes; no timeline errors reported)

## Manual QA note
No logged-in mobile browser session was available in the worker. Expected mobile behavior: at normal end-of-feed, the bottom shows "You're all caught up"; if `/users/timeline` next-page fetch fails, it shows "Couldn't load more timeline items" plus "Try again" and does not auto-retry forever.
