### PR TITLE
perf: speed up activity photo proof uploads

### DIFF
--- a/apps/backend-node/src/routes/activities.ts
+++ b/apps/backend-node/src/routes/activities.ts
@@ -330,6 +330,78 @@ const uploadActivityEntryPhotos = async (
   );
 };
 
+const notifyConnectionsAboutActivityPhotos = async ({
+  user,
+  activity,
+  entry,
+  quantity,
+  uploadedImageCount,
+}: {
+  user: NonNullable<AuthenticatedRequest["user"]>;
+  activity: { title: string; emoji: string; measure: string };
+  entry: ActivityEntry;
+  quantity: string | number;
+  uploadedImageCount: number;
+}) => {
+  const startedAt = Date.now();
+  try {
+    const userWithConnections = await prisma.user.findUnique({
+      where: { id: user.id },
+      include: {
+        connectionsFrom: {
+          where: { status: "ACCEPTED" },
+          include: { to: true },
+        },
+        connectionsTo: {
+          where: { status: "ACCEPTED" },
+          include: { from: true },
+        },
+      },
+    });
+
+    if (!userWithConnections) return;
+
+    const connectedUsersById = new Map(
+      [
+        ...userWithConnections.connectionsFrom.map((conn) => conn.to),
+        ...userWithConnections.connectionsTo.map((conn) => conn.from),
+      ].map((connectedUser) => [connectedUser.id, connectedUser])
+    );
+    const connectedUsers = Array.from(connectedUsersById.values());
+
+    if (connectedUsers.length === 0) return;
+
+    const message = `${user.username} logged ${quantity} ${activity.measure} of ${activity.emoji} ${activity.title} with ${uploadedImageCount === 1 ? "a photo" : `${uploadedImageCount} photos`} 📸!`;
+
+    await Promise.all(
+      connectedUsers.map((connectedUser) =>
+        notificationService.createAndProcessNotification({
+          userId: connectedUser.id,
+          message,
+          type: "INFO",
+          relatedId: entry.id,
+          relatedData: {
+            activityEntryId: entry.id,
+            userPicture: user.picture,
+            userName: user.name,
+            userUsername: user.username,
+          },
+        })
+      )
+    );
+
+    logger.info(
+      `Photo activity notifications processed for ${connectedUsers.length} connection(s) in ${Date.now() - startedAt}ms`,
+      { activityEntryId: entry.id }
+    );
+  } catch (error) {
+    logger.error(
+      `Error processing photo activity notifications for entry ${entry.id}:`,
+      error
+    );
+  }
+};
+
 // Get all activities for user
 router.get(
   "/",
@@ -436,6 +508,7 @@ router.post(
           ? timezoneFromCoords(latitude, longitude) ?? clientTimezone
           : clientTimezone;
       const photos = getUploadedActivityEntryPhotos(req);
+      let uploadedImageCount = 0;
 
       // Check if activity exists and belongs to user
       const activity = await prisma.activity.findFirst({
@@ -524,44 +597,7 @@ router.post(
           logger.info(
             `${uploadedImages.length} photo(s) uploaded successfully to S3 for activity entry ${entry.id}`
           );
-
-          // Create notifications for connected users about the photo
-          const userWithConnections = await prisma.user.findUnique({
-            where: { id: req.user!.id },
-            include: {
-              connectionsFrom: {
-                where: { status: "ACCEPTED" },
-                include: { to: true },
-              },
-              connectionsTo: {
-                where: { status: "ACCEPTED" },
-                include: { from: true },
-              },
-            },
-          });
-
-          if (userWithConnections) {
-            const connectedUsers = [
-              ...userWithConnections.connectionsFrom.map((conn) => conn.to),
-              ...userWithConnections.connectionsTo.map((conn) => conn.from),
-            ];
-
-            for (const connectedUser of connectedUsers) {
-              const message = `${req.user!.username} logged ${quantity} ${activity.measure} of ${activity.emoji} ${activity.title} with ${uploadedImages.length === 1 ? "a photo" : `${uploadedImages.length} photos`} 📸!`;
-              await notificationService.createAndProcessNotification({
-                userId: connectedUser.id,
-                message,
-                type: "INFO",
-                relatedId: entry.id,
-                relatedData: {
-                  activityEntryId: entry.id,
-                  userPicture: req.user!.picture,
-                  userName: req.user!.name,
-                  userUsername: req.user!.username,
-                },
-              });
-            }
-          }
+          uploadedImageCount = uploadedImages.length;
         } catch (error) {
           logger.error("Error uploading photo to S3:", error);
           // Continue without photo - don't fail the entire activity logging
@@ -672,6 +708,16 @@ router.post(
         candidates: sharedActivityCandidates.map((c: any) => ({ id: c.activityEntryId, score: c.score })),
       });
       res.json({ ...entry, entry, sharedActivityCandidates, sharedActivityInvite });
+
+      if (uploadedImageCount > 0) {
+        void notifyConnectionsAboutActivityPhotos({
+          user: req.user!,
+          activity,
+          entry,
+          quantity,
+          uploadedImageCount,
+        });
+      }
     } catch (error) {
       logger.error("Error logging activity:", error);
       res.status(500).json({ error: "Failed to log activity" });

--- a/apps/frontend-vite/src/components/ActivityPhotoUploader.tsx
+++ b/apps/frontend-vite/src/components/ActivityPhotoUploader.tsx
@@ -35,11 +35,13 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
 }) => {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [description, setDescription] = useState("");
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const { logActivity: submitActivity, isLoggingActivity } = useActivities();
   const { addToNotificationCount } = useNotifications();
 
   const handleLogActivity = async () => {
     try {
+      setUploadProgress(selectedFiles.length > 0 ? 0 : null);
       const response = await submitActivity({
         activityId: activityData.activityId,
         datetime: activityData.datetime,
@@ -49,6 +51,7 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
         withUserId: activityData.withUserId,
         latitude: activityData.latitude,
         longitude: activityData.longitude,
+        onUploadProgress: setUploadProgress,
       });
 
       if (!response.entry?.id) {
@@ -60,7 +63,21 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
     } catch (error: any) {
       console.error("Error logging activity:", error);
       toast.error("Failed to log activity. Please try again.");
+    } finally {
+      setUploadProgress(null);
     }
+  };
+
+  const getSubmitLabel = () => {
+    if (isLoggingActivity && selectedFiles.length > 0) {
+      return uploadProgress != null && uploadProgress < 100
+        ? `Uploading ${selectedFiles.length} photo${selectedFiles.length === 1 ? "" : "s"}… ${uploadProgress}%`
+        : "Saving activity…";
+    }
+
+    return selectedFiles.length > 0
+      ? `Upload ${selectedFiles.length} photo${selectedFiles.length === 1 ? "" : "s"}`
+      : "Log without photo";
   };
 
   return (
@@ -96,9 +113,7 @@ const ActivityPhotoUploader: React.FC<ActivityPhotoUploaderProps> = ({
           {isLoggingActivity ? (
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
           ) : null}
-          {selectedFiles.length > 0
-            ? `Upload ${selectedFiles.length} photo${selectedFiles.length === 1 ? "" : "s"}`
-            : "Log without photo"}
+          {getSubmitLabel()}
         </Button>
       </div>
     </AppleLikePopover>

--- a/apps/frontend-vite/src/contexts/activities/provider.tsx
+++ b/apps/frontend-vite/src/contexts/activities/provider.tsx
@@ -128,7 +128,17 @@ export const ActivitiesProvider: React.FC<{ children: React.ReactNode }> = ({
         formData.append("photos", photo);
       }
 
-      const response = await api.post("/activities/log-activity", formData);
+      const response = await api.post("/activities/log-activity", formData, {
+        onUploadProgress: (progressEvent) => {
+          if (!data.onUploadProgress || !progressEvent.total) return;
+          data.onUploadProgress(
+            Math.min(
+              100,
+              Math.round((progressEvent.loaded / progressEvent.total) * 100)
+            )
+          );
+        },
+      });
       return response.data;
     },
     onSuccess: async (response: LogActivityResponse, variables) => {

--- a/apps/frontend-vite/src/contexts/activities/types.ts
+++ b/apps/frontend-vite/src/contexts/activities/types.ts
@@ -36,6 +36,7 @@ export interface ActivityLogData {
   withUserId?: string;
   latitude?: number;
   longitude?: number;
+  onUploadProgress?: (percent: number) => void;
 }
 
 export interface ActivitiesContextType {


### PR DESCRIPTION
## Summary
- move connected-user photo activity notifications out of the blocking `/activities/log-activity` response path while preserving fire-and-forget notification fanout + error logging
- thread Axios upload progress through the activity logging context and show `Uploading… N%` / `Saving activity…` states in the mobile Add proof sheet
- deduplicate notification recipients and keep fanout parallel

## Root cause / perf findings
- selected photos were already client-compressed before submit, so the reported frozen `Upload 1 photo` state happens during submit/server response, not during selection/compression
- the backend uploaded photos in parallel, but then awaited connected-user photo notification fanout before returning the activity response
- the frontend showed only a spinner with the unchanged `Upload 1 photo` label, so slow network/server work felt frozen with no progress feedback

## Test plan
- `pnpm install`
- `pnpm --filter @tsw/prisma db:generate`
- `pnpm --filter backend-node exec vitest run src/utils/__tests__/activityEntryImages.test.ts`
- `pnpm --filter backend-node build`
- `pnpm --filter frontend-vite build`
- static added-line security scan
- independent reviewer subagent pass: no security concerns or logic errors

## Manual QA / notes
- Reviewed the user screenshot at `/home/alex/.hermes/image_cache/img_ff94356b96d7.jpg`; it shows the mobile Add proof sheet stuck on `Upload 1 photo` with one selected photo.
- Full mobile browser QA was not completed in this worker run; the change is covered by build/typecheck/backend test verification above and should be smoke-tested on mobile before merge.
