### PR TITLE
fix: unblock local development readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,44 +42,77 @@
 
 ## Running locally
 
-To run the project locally, follow these steps:
+This repository is a pnpm/Turbo monorepo. Use pnpm from the repository root; the legacy `frontend`/`backend` yarn + Python instructions are stale.
 
-1. Navigate to the frontend directory and start the development server:
+### Prerequisites
 
-   ```sh
-   cd frontend
-   yarn dev
-   ```
+- Node.js compatible with the checked-in lockfile.
+- pnpm 10.x (`packageManager` is `pnpm@10.0.0`).
+- Docker Desktop for the local Supabase stack.
+- Supabase CLI. The root `supabase` package may warn about a missing binary on macOS; if `pnpm supabase` is unavailable, install/use a working Supabase CLI separately.
 
-2. Navigate to the backend directory and start the backend server:
-   ```sh
-   cd backend
-   python -m main
-   ```
+### Install and generate
 
-## Installing dependencies
+```sh
+pnpm install --frozen-lockfile
+pnpm --filter @tsw/prisma db:generate
+```
 
-1. Ensure all dependencies are installed beforehand.
+### Environment files
 
-   **frontend**
+Create local env files from the examples:
 
-   ```sh
-   yarn
-   ```
+```sh
+cp apps/backend-node/.env.example apps/backend-node/.env
+cp apps/frontend-vite/.env.example apps/frontend-vite/.env
+```
 
-   **backend** <small>We recommended to use a local virtual environment (.venv):</smalll>
+Minimal local matrix:
 
-   ```sh
-   python -m venv .venv
-   source .venv/bin/activate
-   pip install -r requirements.txt
-   ```
+| Area | Variable(s) | Required for default local build/tests? | Notes |
+| --- | --- | --- | --- |
+| Backend API | `PORT` | No | Defaults to `3000`. |
+| Database | `DATABASE_URL` | Required for running backend against Supabase | Supabase local usually uses `postgresql://postgres:postgres@127.0.0.1:54322/postgres`. |
+| Frontend API | `VITE_BACKEND_URL` | Required for frontend talking to backend | Use `http://localhost:3000` unless `PORT` differs. |
+| Clerk | `VITE_CLERK_PUBLISHABLE_KEY`, `CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, JWT/public-key values used by auth config | Required for real authenticated app flows | Not required for `pnpm build` or default backend unit tests. |
+| AI/embeddings | `OPENROUTER_API_KEY`, `HELICONE_API_KEY`, `OPENAI_API_KEY`, `PERPLEXITY_API_KEY` | No | Default CI tests skip AI/embedding integration suites. Set explicit test flags below to run them with real credentials. |
+| Push/email/payments/storage/integrations | APNs, AWS, SES/SMTP, Stripe, Telegram, Linear, PostHog variables | No | Needed only for those production-like features. |
 
-2. Make sure you have a [ngrok account and auth token setup](https://ngrok.com/docs/getting-started/)
-3. Make sure you create and link your [clerk](https://clerk.com/) account and link the necessary env vars
-   - frontend
-     - `CLERK_SECRET_KEY`
-     - `CLERK_JWT_PUBLIC_KEY`
-   - backend
-     - `CLERK_JWT_PUBLIC_KEY` (get this in API Keys > Show JWT Public Key)
-4.
+### Start the local database
+
+```sh
+supabase start
+pnpm --filter @tsw/prisma db:push
+```
+
+If you use the Supabase defaults, set backend `DATABASE_URL` to the local DB URL printed by `supabase start` (commonly `postgresql://postgres:postgres@127.0.0.1:54322/postgres`).
+
+### Run backend and frontend
+
+In separate terminals:
+
+```sh
+pnpm --filter backend-node dev
+pnpm --filter frontend-vite dev
+```
+
+Backend health should be available at `http://localhost:3000/health`. Vite will print the frontend URL, usually `http://localhost:5173`.
+
+### Verification commands
+
+```sh
+pnpm build
+pnpm --filter frontend-vite lint
+pnpm --filter backend-node lint
+pnpm --filter backend-node test:ci
+pnpm --filter e2e-tests exec playwright test --list
+```
+
+Backend `test:ci` uses `vitest run` and is non-watch. AI/embedding integration suites are skipped by default so local/CI tests do not require real API keys. To run them intentionally, provide the required database/API credentials and set:
+
+```sh
+RUN_AI_INTEGRATION_TESTS=true pnpm --filter backend-node test:ci
+RUN_PLAN_SIMILARITY_INTEGRATION_TESTS=true pnpm --filter backend-node test:ci
+```
+
+The `e2e-tests` package is included in the pnpm workspace so Playwright dependency resolution and test listing are deterministic from the repo root.

--- a/apps/backend-node/.eslintrc.cjs
+++ b/apps/backend-node/.eslintrc.cjs
@@ -1,0 +1,27 @@
+module.exports = {
+  root: true,
+  env: {
+    es2022: true,
+    node: true,
+  },
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+  plugins: ["@typescript-eslint"],
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  ignorePatterns: ["dist/", "node_modules/"],
+  rules: {
+    "prefer-const": "warn",
+    "no-var": "warn",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-non-null-asserted-optional-chain": "warn",
+    "@typescript-eslint/no-this-alias": "warn",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
+    ],
+    "@typescript-eslint/no-var-requires": "warn",
+  },
+};

--- a/apps/backend-node/package.json
+++ b/apps/backend-node/package.json
@@ -12,7 +12,7 @@
     "dev:proddb": "dotenv -e .env.prod -e .env -- tsx watch src/index.ts",
     "dev:debug": "dotenv -e .env -- ts-node-dev --inspect=9229 --respawn --transpile-only -r tsconfig-paths/register src/index.ts",
     "test": "dotenv -e .env -- vitest --bail=1",
-    "test:ci": "vitest",
+    "test:ci": "vitest run",
     "start": "tsx src/index.ts",
     "db:seed": "dotenv -e .env -- tsx scripts/seed.ts",
     "backfill-activity-categories": "export SKIP_SERVER_START=true && dotenv -e .env -- tsx scripts/backfill_activity_categories.ts",

--- a/apps/backend-node/src/services/__tests__/coaching.test.ts
+++ b/apps/backend-node/src/services/__tests__/coaching.test.ts
@@ -21,6 +21,8 @@ const testUserId1 = "test-coach-user-1";
 const testUserId2 = "test-coach-user-2";
 const testUserId3 = "test-coach-user-3";
 const testUserId4 = "test-coach-user-4";
+const describeIfAiIntegrationEnabled =
+  process.env.RUN_AI_INTEGRATION_TESTS === "true" ? describe : describe.skip;
 
 interface TestScenario {
   name: string;
@@ -101,6 +103,7 @@ async function createTestScenario(scenario: TestScenario): Promise<{
         userId: scenario.userId,
         activityId: createdActivities[0].id,
         date: entryDate,
+        datetime: entryDate,
         quantity: 1,
       },
     });
@@ -256,7 +259,7 @@ async function evaluateCoachNotes(
   }
 }
 
-describe("Coaching Messages Tests", () => {
+describeIfAiIntegrationEnabled("Coaching Messages Tests", () => {
   beforeAll(async () => {
     // Create test users
     const users = [testUserId1, testUserId2, testUserId3, testUserId4];
@@ -576,7 +579,7 @@ describe("Coaching Messages Tests", () => {
   });
 });
 
-describe("Coach Notes Tests", () => {
+describeIfAiIntegrationEnabled("Coach Notes Tests", () => {
   beforeAll(async () => {
     // Create test users
     const users = [testUserId1, testUserId2, testUserId3, testUserId4];

--- a/apps/backend-node/src/services/__tests__/planSimilarity.integration.test.ts
+++ b/apps/backend-node/src/services/__tests__/planSimilarity.integration.test.ts
@@ -9,6 +9,10 @@ const testUserId1 = "cmev4pw6x0000yz1sefkbyy1l";
 const testUserId2 = "cmf55cdau0001yy1injs56d1y";
 const testUserId3 = "cmf55nb160000yw1t6rwa2fuc";
 const testUserId4 = "cmf59yhp30000yu1h1nkji9fr";
+const describeIfPlanSimilarityIntegrationEnabled =
+  process.env.RUN_PLAN_SIMILARITY_INTEGRATION_TESTS === "true"
+    ? describe
+    : describe.skip;
 // TODO: these activities are not being used for anything rn, just match based on plan similarity
 async function createTestPlanWithActivities(
   userId: string,
@@ -105,7 +109,7 @@ async function getMostSimilarPlan(
   }
 }
 
-describe("Plan Similarity Integration Tests", () => {
+describeIfPlanSimilarityIntegrationEnabled("Plan Similarity Integration Tests", () => {
   beforeAll(async () => {
     // Create test users
     const users = [testUserId1, testUserId2, testUserId3, testUserId4];

--- a/apps/backend-node/src/services/aiService.ts
+++ b/apps/backend-node/src/services/aiService.ts
@@ -24,7 +24,9 @@ export class AIService {
     this.model = process.env.OPENROUTER_MODEL || "openai/gpt-5.4-mini";
 
     if (!process.env.OPENROUTER_API_KEY || !process.env.HELICONE_API_KEY) {
-      throw new Error("OPENROUTER_API_KEY or HELICONE_API_KEY is not set");
+      logger.warn(
+        "OPENROUTER_API_KEY or HELICONE_API_KEY is not set - AI calls will fail until credentials are configured"
+      );
     }
   }
 

--- a/apps/backend-node/src/services/planGenerationPipeline.ts
+++ b/apps/backend-node/src/services/planGenerationPipeline.ts
@@ -72,12 +72,8 @@ export class PlanGenerationPipeline {
   private openrouter: OpenRouterProvider;
 
   constructor() {
-    if (!process.env.OPENROUTER_API_KEY) {
-      throw new Error("OPENROUTER_API_KEY is not set");
-    }
-
     this.openrouter = createOpenRouter({
-      apiKey: process.env.OPENROUTER_API_KEY,
+      apiKey: process.env.OPENROUTER_API_KEY || "missing-openrouter-api-key",
       baseURL: process.env.HELICONE_API_KEY
         ? "https://openrouter.helicone.ai/api/v1"
         : undefined,
@@ -112,6 +108,10 @@ export class PlanGenerationPipeline {
    * Research should be done externally via perplexityAiService and passed in.
    */
   async generatePlan(params: PlanGenerationParams): Promise<PipelineResult> {
+    if (!process.env.OPENROUTER_API_KEY) {
+      throw new Error("OPENROUTER_API_KEY is required to generate plans");
+    }
+
     const maxWeeks = params.maxWeeks ?? DEFAULT_MAX_WEEKS;
     const trace: PipelineTraceStep[] = [];
     logger.info(`Starting plan generation pipeline for goal: "${params.goal}" (generating ${maxWeeks} weeks)`);

--- a/apps/frontend-vite/src/components/ActivityLoggerPopover.tsx
+++ b/apps/frontend-vite/src/components/ActivityLoggerPopover.tsx
@@ -61,7 +61,9 @@ export function ActivityLoggerPopover({
           ? `${area}, ${city}`
           : city || area || data.display_name?.split(",")[0];
         if (label) setLocationLabel(label);
-      } catch {}
+      } catch {
+        // Location labels are best-effort only.
+      }
     })();
   }, []);
 

--- a/apps/frontend-vite/src/components/ConversationListItem.tsx
+++ b/apps/frontend-vite/src/components/ConversationListItem.tsx
@@ -32,7 +32,7 @@ export function ConversationListItem({
           avatar: aiCoach.avatar,
           isCoach: true,
         };
-      case "DIRECT":
+      case "DIRECT": {
         // Find the other participant (not current user)
         const otherParticipant = chat.participants?.find(
           (p) => p.userId !== currentUserId
@@ -48,6 +48,7 @@ export function ConversationListItem({
             .slice(0, 2) || "?",
           isCoach: false,
         };
+      }
       case "GROUP":
         return {
           name: chat.title || chat.planGroupName || "Group Chat",

--- a/apps/frontend-vite/src/components/ui/MultiPhotoUploader.tsx
+++ b/apps/frontend-vite/src/components/ui/MultiPhotoUploader.tsx
@@ -78,7 +78,7 @@ const MultiPhotoUploader: React.FC<MultiPhotoUploaderProps> = ({
       }
 
       setIsProcessing(true);
-      let toastId = toast.loading("Processing images...");
+      const toastId = toast.loading("Processing images...");
 
       try {
         const processedFiles: File[] = [];

--- a/apps/frontend-vite/src/components/ui/textarea.tsx
+++ b/apps/frontend-vite/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/apps/frontend-vite/src/components/wrapped/SeasonRunningGraph.tsx
+++ b/apps/frontend-vite/src/components/wrapped/SeasonRunningGraph.tsx
@@ -433,11 +433,12 @@ export const SeasonRunningGraph: React.FC<SeasonRunningGraphProps> = ({
     };
   };
 
-  const visibleImages = useMemo(() => {
-    if (selectedImages.length === 0) return [];
-    const passed = selectedImages.filter(img => img.dayIndex <= exactDayPosition);
-    return passed.slice(-3).reverse();
-  }, [selectedImages, exactDayPosition]);
+  const visibleImages = selectedImages.length === 0
+    ? []
+    : selectedImages
+        .filter((img) => img.dayIndex <= exactDayPosition)
+        .slice(-3)
+        .reverse();
 
   const newestImage = visibleImages[0] || null;
 

--- a/apps/frontend-vite/src/hooks/useMicrophone.ts
+++ b/apps/frontend-vite/src/hooks/useMicrophone.ts
@@ -35,7 +35,7 @@ export const useMicrophone = () => {
         }
 
         const mimeTypes = ["audio/webm", "audio/ogg", "audio/mp4", "audio/wav"];
-        let selectedType = mimeTypes.find((type) =>
+        const selectedType = mimeTypes.find((type) =>
           MediaRecorder.isTypeSupported(type)
         );
 

--- a/apps/frontend-vite/src/routes/add.tsx
+++ b/apps/frontend-vite/src/routes/add.tsx
@@ -77,7 +77,9 @@ function LogPage() {
             longitude: pos.longitude,
           };
         }
-      } catch {}
+      } catch {
+        // Geolocation is optional for manual activity logging.
+      }
 
       setCurrentActivityLogData(logData);
       setShowActivityLogger(false);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,6 +527,21 @@ importers:
         specifier: 7.0.0
         version: 7.0.0(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.0)
 
+  e2e-tests:
+    devDependencies:
+      '@clerk/testing':
+        specifier: ^1.3.30
+        version: 1.14.8(@playwright/test@1.60.0)(react@19.1.1)
+      '@playwright/test':
+        specifier: ^1.49.0
+        version: 1.60.0
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.17.0
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+
   packages/prisma:
     dependencies:
       '@prisma/client':
@@ -1058,6 +1073,10 @@ packages:
     resolution: {integrity: sha512-zmd0jPyb1iALlmyzyRbgujQXrGqw8sf+VpFjm5GkndpBeq5+9+oH7QgMaFEmWi9oxvTd2sZ+EN+QT4+OXPUnGA==}
     engines: {node: '>=14'}
 
+  '@clerk/backend@2.33.5':
+    resolution: {integrity: sha512-YOzUYJfb1d4w+0rKKm+LnnNpkJGQ+NI/g7qmF3mgaSN9X9huteuwCZyufdsI7z2DDkwy/yGRgb9eUWV96t7xLg==}
+    engines: {node: '>=18.17.0'}
+
   '@clerk/backend@2.6.2':
     resolution: {integrity: sha512-IUTjLmA1QkqoJnB97S8Ay/oeFR1QtBxxzi9V2J8zncGdUUpAHRp9PfbUwe203VEZuoDD8n6PGfK4oiiq5CoKhQ==}
     engines: {node: '>=18.17.0'}
@@ -1112,10 +1131,38 @@ packages:
       react-dom:
         optional: true
 
+  '@clerk/shared@3.47.7':
+    resolution: {integrity: sha512-9Yv4MJFEaC7BzV0whxa4txQ4SoMu/3j1LBnI85EBykb5CcfXxIKvNX/9sjMUUySHlTOjsj7XZa5i3W5Dx02K/Q==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/testing@1.14.8':
+    resolution: {integrity: sha512-w6HxhMrza3fD6XB0yy7TEHkAERPYYzpQ79bEvW8sJeCPcLIJ7nF/yaDzDpiLdn97yFW4i1YHKJIlD6J7Exi9Tw==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      '@playwright/test': ^1
+      cypress: ^13 || ^14
+    peerDependenciesMeta:
+      '@playwright/test':
+        optional: true
+      cypress:
+        optional: true
+
   '@clerk/types@3.65.5':
     resolution: {integrity: sha512-RGO8v2a52Ybo1jwVj42UWT8VKyxAk/qOxrkA3VNIYBNEajPSmZNa9r9MTgqSgZRyz1XTlQHdVb7UK7q78yAGfA==}
     engines: {node: '>=14'}
     deprecated: 'This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
+
+  '@clerk/types@4.101.25':
+    resolution: {integrity: sha512-gPxm3hlBkP7B9EfKyp3/UDonNOjg7Z0UvqfrMj5u8gA8nyzvC1UFYtSTTmTfgSY82+5Yo38YV0DYu9vNf6t9CQ==}
+    engines: {node: '>=18.17.0'}
 
   '@clerk/types@4.26.0':
     resolution: {integrity: sha512-VGcrQz/XpCiGbpIIzKVwWw4nLorzKnIP1IAemj1xt/80ULcdEZCncwhas6PoYBBsl1W55A1SwP9B/pEs0nmkCw==}
@@ -2031,6 +2078,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/client@6.13.0':
     resolution: {integrity: sha512-8m2+I3dQovkV8CkDMluiwEV1TxV9EXdT6xaCz39O6jYw7mkf5gwfmi+cL4LJsEPwz5tG7sreBwkRpEMJedGYUQ==}
@@ -4558,6 +4610,10 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  dotenv@17.2.2:
+    resolution: {integrity: sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==}
+    engines: {node: '>=12'}
+
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
@@ -5053,6 +5109,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -5662,6 +5723,10 @@ packages:
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
+
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -6505,6 +6570,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plimit-lit@1.6.1:
     resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
@@ -9116,6 +9191,16 @@ snapshots:
     transitivePeerDependencies:
       - react
 
+  '@clerk/backend@2.33.5(react@19.1.1)':
+    dependencies:
+      '@clerk/shared': 3.47.7(react@19.1.1)
+      '@clerk/types': 4.101.25(react@19.1.1)
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@clerk/backend@2.6.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@clerk/shared': 3.17.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -9191,9 +9276,39 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
+  '@clerk/shared@3.47.7(react@19.1.1)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.7
+      std-env: 3.9.0
+      swr: 2.3.4(react@19.1.1)
+    optionalDependencies:
+      react: 19.1.1
+
+  '@clerk/testing@1.14.8(@playwright/test@1.60.0)(react@19.1.1)':
+    dependencies:
+      '@clerk/backend': 2.33.5(react@19.1.1)
+      '@clerk/shared': 3.47.7(react@19.1.1)
+      '@clerk/types': 4.101.25(react@19.1.1)
+      dotenv: 17.2.2
+    optionalDependencies:
+      '@playwright/test': 1.60.0
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@clerk/types@3.65.5':
     dependencies:
       csstype: 3.1.1
+
+  '@clerk/types@4.101.25(react@19.1.1)':
+    dependencies:
+      '@clerk/shared': 3.47.7(react@19.1.1)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@clerk/types@4.26.0':
     dependencies:
@@ -9771,7 +9886,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -9784,14 +9899,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@swc/core@1.13.19)(@types/node@20.19.9)(typescript@5.9.2))
+      jest-config: 29.7.0(@types/node@24.5.2)(ts-node@10.9.2(@swc/core@1.13.19)(@types/node@20.19.9)(typescript@5.9.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -9816,7 +9931,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -9834,7 +9949,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -9856,7 +9971,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.29
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -9926,7 +10041,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -10055,6 +10170,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@prisma/client@6.13.0(prisma@6.13.0(typescript@5.9.2))(typescript@5.9.2)':
     optionalDependencies:
@@ -11389,7 +11508,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
 
   '@types/canvas-confetti@1.9.0': {}
 
@@ -11400,14 +11519,14 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
 
   '@types/cookies@0.7.7':
     dependencies:
       '@types/connect': 3.4.38
       '@types/express': 4.17.23
       '@types/keygrip': 1.0.6
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
 
   '@types/cors@2.8.19':
     dependencies:
@@ -11461,7 +11580,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
@@ -11492,7 +11611,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
 
   '@types/hast@3.0.4':
     dependencies:
@@ -11548,7 +11667,7 @@ snapshots:
 
   '@types/node-fetch@2.6.2':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       form-data: 3.0.4
 
   '@types/node@16.18.6': {}
@@ -11611,12 +11730,12 @@ snapshots:
   '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
 
   '@types/serve-static@1.15.8':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       '@types/send': 0.17.5
 
   '@types/serviceworker@0.0.153': {}
@@ -12837,6 +12956,8 @@ snapshots:
 
   dotenv@16.6.1: {}
 
+  dotenv@17.2.2: {}
+
   dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
@@ -13492,6 +13613,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -13981,7 +14105,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.0
@@ -14051,6 +14175,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@29.7.0(@types/node@24.5.2)(ts-node@10.9.2(@swc/core@1.13.19)(@types/node@20.19.9)(typescript@5.9.2)):
+    dependencies:
+      '@babel/core': 7.28.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.5.2
+      ts-node: 10.9.2(@swc/core@1.13.19)(@types/node@20.19.9)(typescript@5.9.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@29.7.0:
     dependencies:
       chalk: 4.1.2
@@ -14075,7 +14230,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -14085,7 +14240,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -14124,7 +14279,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -14159,7 +14314,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -14187,7 +14342,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -14233,7 +14388,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -14252,7 +14407,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -14268,7 +14423,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 24.5.2
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -14292,6 +14447,8 @@ snapshots:
   js-cookie@3.0.1: {}
 
   js-cookie@3.0.5: {}
+
+  js-cookie@3.0.7: {}
 
   js-tokens@4.0.0: {}
 
@@ -15258,6 +15415,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plimit-lit@1.6.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "e2e-tests"


### PR DESCRIPTION
## Summary
- Fixes frontend lint hard errors while leaving existing warnings non-blocking.
- Adds backend ESLint config and switches backend CI tests to non-watch vitest run.
- Skips credentialed AI/embedding integration suites by default, fixes stale ActivityEntry datetime fixture, and avoids import-time credential failures.
- Adds e2e-tests to the pnpm workspace and updates README local setup docs.

## Verification
- pnpm install --frozen-lockfile
- pnpm build
- pnpm --filter frontend-vite lint
- pnpm --filter backend-node lint
- pnpm --filter backend-node test:ci
- pnpm --filter e2e-tests exec playwright test --list